### PR TITLE
View Current User Posts (Ticket 4)

### DIFF
--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -1,8 +1,10 @@
 import { useRef, useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { loginUser } from "../../managers/AuthManager"
+import { useCurrentUser } from "../../context/CurrentUserContext"
 
 export const Login = ({ setToken }) => {
+  const { fetchUserData } = useCurrentUser()
   const username = useRef()
   const password = useRef()
   const navigate = useNavigate()
@@ -19,6 +21,11 @@ export const Login = ({ setToken }) => {
     loginUser(user).then(res => {
       if ("valid" in res && res.valid) {
         setToken(res.token)
+
+        const userObj = { id: res.token }
+        localStorage.setItem("auth_token", JSON.stringify(userObj))
+        fetchUserData()
+
         navigate("/")
       }
       else {

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -1,5 +1,6 @@
 import { useRef } from "react"
 import { Link, useNavigate } from "react-router-dom"
+import { useCurrentUser } from "../../context/CurrentUserContext"
 import "./NavBar.css"
 import Logo from "./rare.jpeg"
 
@@ -7,6 +8,7 @@ export const NavBar = ({ token, setToken }) => {
   const navigate = useNavigate()
   const navbar = useRef()
   const hamburger = useRef()
+  const { setCurrentUser } = useCurrentUser()
 
   const showMobileNavbar = () => {
     hamburger.current.classList.toggle('is-active')
@@ -33,7 +35,10 @@ export const NavBar = ({ token, setToken }) => {
           {
             token
               ?
-              <Link to="/" className="navbar-item">Posts</Link>
+              <>
+                <Link to="/my-posts" className="navbar-item">My Posts</Link>
+                {/* Add additional links for NavBar here */}
+              </>
               :
               ""
           }
@@ -47,6 +52,8 @@ export const NavBar = ({ token, setToken }) => {
                   ?
                   <button className="button is-outlined" onClick={() => {
                     setToken('')
+                    localStorage.removeItem('auth_token')
+                    setCurrentUser(null)
                     navigate('/login')
                   }}>Logout</button>
                   :

--- a/src/components/posts/MyPosts.jsx
+++ b/src/components/posts/MyPosts.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { getPostByUserIdExpandCategory } from "../../services";
+import { useCurrentUser } from "../../context/CurrentUserContext.js";
+
+// React component to display the all of the current logged in user's posts
+export const MyPosts = () => {
+  const { currentUser, isLoading: userLoading } = useCurrentUser();
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (currentUser) {
+      getPostByUserIdExpandCategory(currentUser.id).then(fetchedPosts => {
+        const sortedPosts = fetchedPosts.sort((a, b) =>
+          new Date(b.publication_date) - new Date(a.publication_date)
+        );
+        setPosts(sortedPosts);
+        setLoading(false);
+      }).catch(error => {
+        console.error("Failed to fetch posts:", error);
+        setPosts([]);
+        setLoading(false);
+      });
+    } else {
+      setLoading(false);
+    }
+  }, [currentUser]);
+
+  if (loading || userLoading) {
+    return <p>Loading posts...</p>;
+  }
+
+  if (!posts.length) {
+    return <p>No posts found.</p>;
+  }
+
+  return (
+    <div>
+      <h2>My Posts</h2>
+      <ul>
+        {posts.map(post => (
+          <li key={post.id}>
+            <strong>{post.title}</strong>
+            <div>Author: {currentUser?.first_name} {currentUser?.last_name}</div>
+            <div>Category: {post.category?.label}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/context/CurrentUserContext.js
+++ b/src/context/CurrentUserContext.js
@@ -1,0 +1,8 @@
+// This file creates a Context for sharing the current logged-in employee data across the entire app.
+// It allows any component to access currentUser without having to pass it down through props.
+// Use the useCurrentUser() hook in any component to access the current user data.
+
+import { createContext, useContext } from 'react';
+export const CurrentUserContext = createContext();
+export const useCurrentUser = () => useContext(CurrentUserContext);
+export { CurrentUserProvider } from './CurrentUserContext.jsx';

--- a/src/context/CurrentUserContext.jsx
+++ b/src/context/CurrentUserContext.jsx
@@ -1,0 +1,51 @@
+// This Provider component wraps our entire app and manages the currentUser state.
+// When the app loads, it checks localStorage for a logged-in user and fetches their full data from the API.
+// It provides both currentUser (the data) and setCurrentUser (to update it) to all child components.
+// This runs automatically on app load and whenever someone logs in/out.
+// Use the useCurrentUser() hook in any component to access the user data.
+// Wrap your app with <CurrentUserProvider> in src/main.jsx after importing it.
+import { CurrentUserContext } from "./CurrentUserContext.js";
+import { useState, useEffect } from "react";
+import { getUserById } from "../services";
+
+export const CurrentUserProvider = ({ children }) => {
+  const [currentUser, setCurrentUser] = useState(null);
+
+  // Initialize isLoading based on whether there's a user in localStorage
+  const [isLoading, setIsLoading] = useState(() => {
+    return localStorage.getItem("auth_token") !== null;
+  });
+
+  const fetchUserData = () => {
+    const localUser = localStorage.getItem("auth_token");
+
+    if (localUser) {
+      setIsLoading(true);
+      const userObject = JSON.parse(localUser);
+      getUserById(userObject.id)
+        .then((user) => {
+          setCurrentUser(user);
+        })
+        .catch((error) => {
+          console.error("Failed to fetch user data:", error);
+          setCurrentUser(null);
+          localStorage.removeItem("auth_token");
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  };
+
+  useEffect(() => {
+    fetchUserData();
+  }, []);
+
+  return (
+    <CurrentUserContext.Provider
+      value={{ currentUser, setCurrentUser, isLoading, fetchUserData }}
+    >
+      {children}
+    </CurrentUserContext.Provider>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,14 @@ import { createRoot } from "react-dom/client"
 import { BrowserRouter } from "react-router-dom"
 import { Rare } from "./Rare"
 import "./index.css"
+import { CurrentUserProvider } from "./context/CurrentUserContext"
 
 const container = document.getElementById("root")
 const root = createRoot(container)
 root.render(
     <BrowserRouter>
-        <Rare />
+        <CurrentUserProvider>
+            <Rare />
+        </CurrentUserProvider>
     </BrowserRouter>
 )

--- a/src/services/PostService.js
+++ b/src/services/PostService.js
@@ -1,0 +1,9 @@
+import { fetchJson } from "./apiSettings";
+
+export function getPostsByUserId(userId) {
+    return fetchJson(`/posts?user_id=${userId}`);
+}
+
+export function getPostByUserIdExpandCategory(userId) {
+    return fetchJson(`/posts?user_id=${userId}&_expand=category`);
+}

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -1,0 +1,5 @@
+import { fetchJson } from "./apiSettings.js";
+
+export function getUserById(id) {
+    return fetchJson(`/users/${id}`);
+}

--- a/src/services/apiSettings.js
+++ b/src/services/apiSettings.js
@@ -1,0 +1,53 @@
+export const API_BASE_URL = "http://localhost:8088";
+
+export const fetchJson = async (endpoint, options = {}) => {
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        headers: { "Content-Type": "application/json" },
+        ...options
+    });
+    if (!response.ok) {
+        throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+};
+
+export const postJson = async (endpoint, data) => {
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data)
+    });
+
+    if (!response.ok) {
+        throw new Error(`POST failed: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+};
+
+export const putJson = async (endpoint, data) => {
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data)
+    });
+
+    if (!response.ok) {
+        throw new Error(`PUT failed: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+};
+
+export const deleteJson = async (endpoint) => {
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        method: "DELETE"
+    });
+
+    if (!response.ok) {
+        throw new Error(`DELETE failed: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+};

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,5 @@
+// Users
+export { getUserById } from "./UserService.js";
+
+// Posts
+export { getPostsByUserId, getPostByUserIdExpandCategory } from "./PostService.js";

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -1,16 +1,18 @@
-import { Route, Routes } from "react-router-dom"
+import { Route, Routes, Navigate } from "react-router-dom"
 import { Login } from "../components/auth/Login"
 import { Register } from "../components/auth/Register"
 import { Authorized } from "./Authorized"
+import { MyPosts } from "../components/posts/MyPosts"
 
 export const ApplicationViews = ({ token, setToken }) => {
   return <>
     <Routes>
-      <Route path="/login" element={<Login setToken={setToken} />}  />
-      <Route path="/register" element={<Register setToken={setToken} />}  />
+      <Route path="/" element={<Navigate to="/my-posts" replace />} />
+      <Route path="/login" element={<Login setToken={setToken} />} />
+      <Route path="/register" element={<Register setToken={setToken} />} />
       <Route element={<Authorized token={token} />}>
-        {/* Add Routes here */}
-        
+        {/* Add additional route here */}
+        <Route path="my-posts" element={<MyPosts />} />
       </Route>
     </Routes>
   </>


### PR DESCRIPTION
# Description

Adds a global current user context to manage authenticated user state across the app, persists auth state in localStorage using `auth_token`, and introduces a new **My Posts** view that displays posts created by the logged-in user.

## Changes

* [ ] Bug fix
* [x] New feature

## Testing

* Requires fetching backend `dh/view_current_user_posts_4` for API functionality
* Logged in and verified user data is fetched and stored in context
* Confirmed auth state persists on refresh
* Navigated to **My Posts** and verified only the current user’s posts render
* Logged out and confirmed auth state and user context are cleared

## Notes

* App is now wrapped in `CurrentUserProvider`
* NavBar updated to reflect authenticated state and new route
* Services layer added for users and posts
