### PR TITLE
added tag manager tab with create a tag component

### DIFF
--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -41,6 +41,7 @@ export const NavBar = ({ token, setToken }) => {
                 <Link to="/all-posts" className="navbar-item">All Posts</Link>
                 <Link to="/bulma-sampler" className="navbar-item">Bulma Sampler</Link>
                 {/* Add additional links for NavBar here */}
+                <Link to="/tags" className="navbar-item">Tag Manager</Link>
               </>
               :
               ""

--- a/src/components/tags/NewTag.jsx
+++ b/src/components/tags/NewTag.jsx
@@ -1,0 +1,46 @@
+//Component for a form to create a new tag and submit it to the API
+
+import { useState } from "react";
+import { createTag } from "../../services/TagService";
+import { useNavigate } from "react-router-dom";
+import { Container, Form, FormField, PageHeader } from "../../design";
+
+export const NewTag = () => {
+    const [label, setLabel] = useState("");
+    const navigate = useNavigate();
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (label.trim()) {
+            createTag({ label }).then(() => {
+                navigate("/tags");
+            }).catch(error => {
+                console.error("Failed to create tag:", error);
+            });
+        }    };
+
+    return (
+        <Container>
+            <PageHeader title={`Create a New Tag`}/>
+            <Form onSubmit={handleSubmit}>
+                <FormField label="Tag Name">
+                    <input
+                        className="input"
+                        type="text"
+                        value={label}
+                        onChange={(e) => setLabel(e.target.value)}
+                        required
+                    />
+                </FormField>
+                <div className="field is-grouped">
+                    <div className="control">
+                        <button className="button is-link" type="submit">Save Tag</button>
+                    </div>
+                    <div className="control">
+                        <button className="button is-link is-light" type="button" onClick={() => navigate("/tags")}>Cancel</button>
+                    </div>
+                </div>
+            </Form>
+        </Container>
+    );
+}   

--- a/src/components/tags/TagList.jsx
+++ b/src/components/tags/TagList.jsx
@@ -1,0 +1,15 @@
+import { useNavigate } from "react-router-dom"
+import { Button, Container, PageHeader} from "../../design";
+
+export const TagList = () => {
+    const navigate = useNavigate();
+
+    return (
+        <Container>
+            <PageHeader title="Tag List" />
+            {/* A List of all Tags will display here. Ticket #10 */}
+            <Button onClick={() => navigate("/tags/new")}>Create a Tag</Button>
+        </Container>
+ 
+    )
+}

--- a/src/services/TagService.js
+++ b/src/services/TagService.js
@@ -1,0 +1,10 @@
+import { fetchJson, postJson } from "./apiSettings";
+
+// Function to get all tags from the API Ticket #10
+export const getAllTags = () => {
+    return fetchJson("/tags");
+}
+
+export const createTag = (tag) => {
+    return postJson("/tags", tag);
+}

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -13,6 +13,8 @@ import { PostDetails } from "../components/posts/PostDetails"
 import { CreateAPost } from "../components/posts/CreateAPost"
 import { PostComments } from "../components/comments/PostComments.jsx"
 import { ButtonDemo } from "../design/bulma-reference/ButtonDemo"
+import { TagList } from "../components/tags/TagList.jsx"
+import { NewTag } from "../components/tags/NewTag.jsx"
 
 export const ApplicationViews = ({ token, setToken }) => {
   return <>
@@ -33,6 +35,9 @@ export const ApplicationViews = ({ token, setToken }) => {
         {/* Ticket #5 - Route for viewing a single post's details */}
         <Route path="posts/:postId" element={<PostDetails />} />
         <Route path="posts/:postId/comments" element={<PostComments />} />
+        {/* Ticket #8 - Route for viewing the Tag List */}
+        <Route path="tags" element={<TagList />} />
+        <Route path="tags/new" element={<NewTag />} />
       </Route>
     </Routes>
   </>


### PR DESCRIPTION
# Description

Adds a Tag Manager feature, allowing authenticated users to view and create tags. This includes a new TagList page, a NewTag form, a TagService for API calls, updated routing, and a NavBar link.

## Changes

- [ ] Bug fix  
- [x] New feature  

## Testing


- Logged in as an authenticated user and confirmed "Tag Manager" appears in the NavBar
- Navigated to /tags and confirmed the Tag List page renders with a "Create a Tag" button
- Clicked "Create a Tag", filled out the form, and confirmed submission redirects back to /tags
- Clicked "Cancel" on the new tag form and confirmed it navigates back to /tags without creating a tag
- Confirmed the form does not submit if the tag name is empty or whitespace only


## Notes

- TagList currently has a placeholder comment where the list of tags will render — that display logic is tracked under Ticket #13 
- getAllTags is defined in TagService.js but not yet consumed by TagList; it will be wired up in the follow-on ticket
