### PR TITLE
Activate and Deactivate a User Profile (Ticket 28 and 29)

### DIFF
--- a/src/components/auth/Login.jsx
+++ b/src/components/auth/Login.jsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { loginUser } from "../../managers/AuthManager"
+import { getUserById } from "../../services"
 import { QuickLogin } from "./QuickLogin"
 import { useCurrentUser } from "../../context/CurrentUserContext"
 
@@ -22,7 +23,7 @@ export const Login = ({ setToken }) => {
   const [isUnsuccessful, setisUnsuccessful] = useState(false)
   const { fetchUserData } = useCurrentUser()
 
-  const handleLogin = (e) => {
+  const handleLogin = async (e) => {
     e.preventDefault()
 
     const user = {
@@ -30,16 +31,19 @@ export const Login = ({ setToken }) => {
       password: password.current.value
     }
 
-    loginUser(user).then(res => {
-      if ("valid" in res && res.valid) {
-        setToken(res.token)
-        fetchUserData()
-        navigate("/")
-      }
-      else {
+    const res = await loginUser(user)
+    if ("valid" in res && res.valid) {
+      const userData = await getUserById(res.token)
+      if (!userData.active) {
         setisUnsuccessful(true)
+        return
       }
-    })
+      setToken(res.token)
+      fetchUserData()
+      navigate("/")
+    } else {
+      setisUnsuccessful(true)
+    }
   }
 
   return (

--- a/src/components/users/UserProfiles.jsx
+++ b/src/components/users/UserProfiles.jsx
@@ -1,42 +1,88 @@
 // Component for displaying all user profiles.
-import { useEffect, useState } from "react"
+import { useEffect, useState, useRef } from "react"
 import { useNavigate } from "react-router-dom"
-import { getAllUsers } from "../../services/index.js"
-import { Loading, PageHeader, Container, Card} from "../../design"
+import { getAllUsers, getInactiveUsers, getActiveUsers, updateUser } from "../../services/index.js"
+import { Loading, PageHeader, Container, Card, ConfirmDialog, Button} from "../../design"
 import { useCurrentUser } from "../../context/CurrentUserContext.js"
 import "./UserProfiles.css"
 
 export const UserProfiles = () => {
   const [users, setUsers] = useState([])
+  const [activeFilter, setActiveFilter] = useState("all")
   const [loading, setLoading] = useState(true)
+
+  // State to trigger re-fetching users after toggling active status
+  // This refreshKey state is used to trigger the useEffect hook to re-fetch the user list whenever a user's active status is toggled. 
+  // By incrementing this key, we can ensure that the latest user data is loaded without having to directly manipulate the users state after an update.
+  const [refreshKey, setRefreshKey] = useState(0)
+
   const navigate = useNavigate()
+
   const { currentUser } = useCurrentUser()
+  // Ref for the confirmation dialog
+  // useRef hook is used to get a reference to the ConfirmDialog component, allowing us to programmatically control its visibility and content when toggling user active status.
+  const dialogRef = useRef()
 
-    useEffect(() => {
-        let isMounted = true
+  const [selectedUser, setSelectedUser] = useState(null)
 
-        const loadUsers = async () => {
+  useEffect(() => {
+      let isMounted = true
+
+      const loadUsers = async () => {
             setLoading(true)
             try {
-                const usersData = await getAllUsers()
+                let usersData
+                if (activeFilter === "active") {
+                    usersData = await getActiveUsers()
+                } else if (activeFilter === "inactive") {
+                    usersData = await getInactiveUsers()
+                } else {
+                    usersData = await getAllUsers()
+                }
+
                 if (isMounted) {
-                    setUsers(usersData)
+                    setUsers(usersData.map((u) => ({ ...u, active: Boolean(u.active) })))
                 }
             } finally {
                 if (isMounted) {
                     setLoading(false)
                 }
             }
-        }
+      }
 
-        loadUsers()
+      loadUsers()
 
-        return () => {
+      return () => {
             isMounted = false
-        }
-    }, [])
+      }
+  }, [activeFilter, refreshKey])
 
-  if (!currentUser || !currentUser.is_staff) {
+  // Handler for toggling user active status - opens confirmation dialog
+  const handleToggleActive = (user) => {
+    setSelectedUser(user)
+    dialogRef.current.showModal()
+  }
+
+// Handler for confirming active status toggle - updates user and refreshes list by incrementing refreshKey
+ const handleConfirmToggle = async () => {
+  if (!selectedUser) return
+
+  const newActiveStatus = !selectedUser.active
+
+  await updateUser(selectedUser.id, { ...selectedUser, active: newActiveStatus })
+
+  setSelectedUser(null)
+  setRefreshKey((prev) => prev + 1)
+}
+
+// Handler for canceling active status toggle - simply closes the confirmation dialog without making changes
+const handleCancelToggle = () => {
+  setSelectedUser(null)
+}
+
+// Access control: only staff users can view this page
+// Redirects non-staff users to an access denied page.
+if (!currentUser || !currentUser.is_staff) {
     navigate("/access-denied", { replace: true })
     return null
   }
@@ -47,66 +93,120 @@ export const UserProfiles = () => {
 
   return (
   <Container>
-    <PageHeader title="Users" centered />
+  <PageHeader title="Users" centered />
 
-    {users.map((user) => (
-      <Card key={user.id}>
-        <div className="user-row">
-          {/* 1) Username */}
-          <div className="user-cell">
-            <strong>Username:</strong>
-            <span>{user.username}</span>
-          </div>
+  {/* Top Filter buttons */}
+  <div className="level-item">
+    <div className="buttons">
+      <Button
+        color="info"
+        variant={activeFilter === "all" ? "outlined" : undefined}
+        onClick={() => setActiveFilter("all")}
+      >
+        All Users
+      </Button>
+      <Button
+        color="info"
+        variant={activeFilter === "active" ? "outlined" : undefined}
+        onClick={() => setActiveFilter("active")}
+      >
+        Active Users
+      </Button>
+      <Button
+        color="info"
+        variant={activeFilter === "inactive" ? "outlined" : undefined}
+        onClick={() => setActiveFilter("inactive")}
+      >
+        Inactive Users
+      </Button>
+    </div>
+  </div>
 
-          <div className="user-divider" />
+  {/* Table */}
+  <Card>
+    <div className="table-container">
+      <table className="table is-fullwidth is-striped is-hoverable">
+        <thead>
+          <tr>
+            <th>Username</th>
+            <th>Name</th>
+            <th>Active Status</th>
+            <th>Author or Admin</th>
+          </tr>
+        </thead>
 
-          {/* 2) Name */}
-          <div className="user-cell">
-            <strong>Name:</strong>
-            <span>
-              {user.first_name} {user.last_name}
-            </span>
-          </div>
+        <tbody>
+          {users.map((user) => (
+            <tr key={user.id}>
+              {/* Username */}
+              <td>{user.username}</td>
 
-          <div className="user-divider" />
+              {/* User Name */}
+              <td>
+                {user.first_name} {user.last_name}
+              </td>
 
-          {/* 3) Active checkbox */}
-          <div className="user-cell user-cell--sm">
-            <label className="checkbox">
-              <input type="checkbox" checked={!!user.active} readOnly />
-              <span style={{ marginLeft: "0.5rem" }}>Active</span>
-            </label>
-          </div>
+              {/* Active Status: checkbox + action button */}
+              <td>
+                <div className="is-flex is-align-items-center" style={{ gap: "0.75rem" }}>
+                  <label className="checkbox">
+                    <input
+                      type="checkbox"
+                      checked={!!user.active}
+                      onChange={(e) => {
+                        // prevent the checkbox from visually toggling before confirmation
+                        e.preventDefault()
+                        handleToggleActive(user)
+                      }}
+                    />
+                    <span style={{ marginLeft: "0.5rem" }}>
+                      {user.active ? "Active" : "Inactive"}
+                    </span>
+                  </label>
+                  
+                  {/* Action button to toggle active status - shows "Deactivate" for active users and "Activate" for inactive users */}
+                  {user.active ? (
+                    <Button
+                      color="danger"
+                      size="small"
+                      onClick={() => handleToggleActive(user)}
+                    >
+                      Deactivate
+                    </Button>
+                  ) : (
+                    <Button
+                      color="success"
+                      size="small"
+                      onClick={() => handleToggleActive(user)}
+                    >
+                      Activate
+                    </Button>
+                  )}
+                </div>
+              </td>
 
-          <div className="user-divider" />
+              {/* Role */}
+              <td>{user.is_staff ? "Admin" : "Author"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </Card>
 
-          {/* 4) Role radios (driven by is_staff) */}
-          <div className="user-cell user-cell--md">
-            <div className="role-group">
-              <label className="radio">
-                <input
-                  type="radio"
-                  name={`role-${user.id}`}
-                  checked={!user.is_staff}
-                  readOnly
-                />
-                <span style={{ marginLeft: "0.5rem" }}>Author</span>
-              </label>
-
-              <label className="radio">
-                <input
-                  type="radio"
-                  name={`role-${user.id}`}
-                  checked={!!user.is_staff}
-                  readOnly
-                />
-                <span style={{ marginLeft: "0.5rem" }}>Admin</span>
-              </label>
-            </div>
-          </div>
-        </div>
-      </Card>
-    ))}
-  </Container>
+  <ConfirmDialog
+    dialogRef={dialogRef}
+    title={selectedUser?.active ? "Deactivate User" : "Activate User"}
+    message={
+      selectedUser?.active
+        ? `Are you sure you want to deactivate ${selectedUser?.first_name} ${selectedUser?.last_name} (${selectedUser?.username})?`
+        : `Are you sure you want to activate ${selectedUser?.first_name} ${selectedUser?.last_name} (${selectedUser?.username})?`
+    }
+    confirmText={selectedUser?.active ? "Yes, Deactivate" : "Yes, Activate"}
+    confirmColor={selectedUser?.active ? "is-danger" : "is-success"}
+    onConfirm={handleConfirmToggle}
+    onCancel={handleCancelToggle}
+  />
+</Container>
 )
 }

--- a/src/design/design.css
+++ b/src/design/design.css
@@ -1,0 +1,19 @@
+.button {
+  transition: all 0.2s ease-in-out;
+}
+
+.button:hover:not(.is-static):not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.15);
+  filter: brightness(1.05);
+}
+
+.button:active:not(.is-static):not([disabled]) {
+  transform: translateY(0);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(0, 150, 136, 0.5);
+  outline-offset: 2px;
+}

--- a/src/design/index.js
+++ b/src/design/index.js
@@ -1,3 +1,5 @@
+import "./design.css"
+
 export { FormField } from "./FormField"
 export { FormTextarea } from "./FormTextarea"
 export { FormSelect } from "./FormSelect"

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -1,4 +1,4 @@
-import { fetchJson } from "./apiSettings.js";
+import { fetchJson, putJson } from "./apiSettings.js";
 
 export function getUserById(id) {
     return fetchJson(`/users/${id}`);
@@ -6,4 +6,16 @@ export function getUserById(id) {
 
 export function getAllUsers() {
     return fetchJson("/users");
+}
+
+export function getActiveUsers() {
+    return fetchJson("/users?active=true");
+}
+
+export function getInactiveUsers() {
+    return fetchJson("/users?active=false");
+}
+
+export const updateUser = (userId, userData) => {
+    return putJson(`/users/${userId}`, userData)
 }

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,5 +1,5 @@
 // Users
-export { getUserById, getAllUsers } from "./UserService.js";
+export { getUserById, getAllUsers, updateUser, getActiveUsers, getInactiveUsers } from "./UserService.js";
 
 // Posts
 export {


### PR DESCRIPTION
# Description

Implements staff-controlled updating of user active status from the User Profiles page. Adds filtering (All / Active / Inactive), confirmation before toggling status, and prevents inactive users from logging in.

## Changes

* [ ] Bug fix
* [x] New feature

## Testing

* Verified staff users can:

  * View all users
  * Filter by All, Active, and Inactive users
  * Toggle a user’s active status via Activate/Deactivate button
* Confirmed confirmation dialog appears before changing status
* Confirmed user list refreshes after status update
* Verified inactive users cannot log in (login is blocked after backend check)
* Confirmed active users can log in normally
* Verified non-staff users cannot access the User Profiles page

## Notes

* Added filtering support (All / Active / Inactive)
* Added confirmation dialog before changing active status
* Added `updateUser` service for PUT requests
* Added login validation to prevent inactive users from authenticating
* Added small button UI improvements and transitions
* Page remains staff-only via existing role-based route guard