### PR TITLE
Ticket #16 Add delete category functionality with confirm dialog

### DIFF
--- a/src/components/categories/CategoriesList.jsx
+++ b/src/components/categories/CategoriesList.jsx
@@ -1,7 +1,7 @@
 // Component to display a list of all categories in the database
-import { useEffect, useState } from "react"
-import { useNavigate } from "react-router-dom"
-import { getAllCategories } from "../../services"
+import { useEffect, useState, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { getAllCategories, deleteCategory } from "../../services";
 import {
   Loading,
   Notification,
@@ -10,26 +10,31 @@ import {
   Card,
   Button,
   IconButton,
-} from "../../design"
+  ConfirmDialog,
+} from "../../design";
 
 export const CategoriesList = () => {
-  const [categories, setCategories] = useState([])
-  const navigate = useNavigate()
-  const [loading, setLoading] = useState(true)
+  const [categories, setCategories] = useState([]);
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  // Ticket #16 - tracks which category's trash button was clicked so the confirm dialog knows what to delete
+  const [selectedCategoryId, setSelectedCategoryId] = useState(null);
+  // Ticket #16 - ref used to open/close the native HTML <dialog> element via .showModal() and .close()
+  const dialogRef = useRef(null);
 
   useEffect(() => {
     getAllCategories()
       .then((fetchedCategories) => {
-        setCategories(fetchedCategories)
+        setCategories(fetchedCategories);
       })
       .catch((error) => {
-        console.error("Failed to fetch categories:", error)
-        setCategories([])
+        console.error("Failed to fetch categories:", error);
+        setCategories([]);
       })
-      .finally(() => setLoading(false))
-  }, [])
+      .finally(() => setLoading(false));
+  }, []);
 
-  if (loading) return <Loading />
+  if (loading) return <Loading />;
 
   if (!categories.length) {
     return (
@@ -43,12 +48,37 @@ export const CategoriesList = () => {
           Create a Category
         </Button>
       </Container>
-    )
+    );
   }
+
+  // Ticket #16 - handles confirmed deletion: calls the API, then filters the deleted category out of state so the UI updates instantly without a page refresh
+  const handleConfirmDelete = () => {
+    deleteCategory(selectedCategoryId).then((response) => {
+      // Filter out the deleted category from local state so the list updates immediately
+      const updatedCategories = categories.filter(
+        (category) => category.id !== selectedCategoryId,
+      );
+      setCategories(updatedCategories);
+    });
+    dialogRef.current?.close(); //This is setup to close the modal and not navigate to another page.
+    setSelectedCategoryId(null); //Good safeguard to help prevent bugs.
+  };
 
   return (
     <Container>
       <PageHeader title="Categories" centered />
+
+      {/* Ticket #16 - confirmation dialog rendered once, opened via dialogRef.current.showModal() when trash is clicked */}
+      <ConfirmDialog
+        dialogRef={dialogRef}
+        title={"Confirm Category Delete"}
+        message={"Are you sure you want to delete this?"}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => {
+          dialogRef.current?.close();
+          setSelectedCategoryId(null);
+        }} //The onCancel is setup to make sure after any cancels that the state is set to null, so that there is no accidental deletion of other categories.
+      />
 
       {categories.map((category) => (
         <Card key={category.id}>
@@ -64,7 +94,10 @@ export const CategoriesList = () => {
                 <IconButton
                   icon="trash"
                   title="Delete category (coming soon)"
-                  onClick={() => {}}
+                  onClick={() => {
+                    setSelectedCategoryId(category.id);
+                    dialogRef.current?.showModal();
+                  }}
                 />
               </div>
             </div>
@@ -73,7 +106,9 @@ export const CategoriesList = () => {
             <div className="media-content">
               <div className="content">
                 <p className="mb-0">
-                  <span className="has-text-weight-semibold">{category.label}</span>
+                  <span className="has-text-weight-semibold">
+                    {category.label}
+                  </span>
                   <hr className="my-2" />
                 </p>
               </div>
@@ -93,5 +128,5 @@ export const CategoriesList = () => {
         </Button>
       </div>
     </Container>
-  )
-}
+  );
+};

--- a/src/services/CategoryService.js
+++ b/src/services/CategoryService.js
@@ -1,9 +1,14 @@
-import { fetchJson, postJson } from "./apiSettings";
+import { fetchJson, postJson, deleteJson } from "./apiSettings";
 
 export function getAllCategories() {
-    return fetchJson("/categories");
+  return fetchJson("/categories");
 }
 
 export function createCategory(category) {
-    return postJson("/categories", category);
+  return postJson("/categories", category);
 }
+
+// Ticket #16 - Delete a Category: sends DELETE request to remove a category by id
+export const deleteCategory = (id) => {
+  return deleteJson(`/categories/${id}`);
+};

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -15,7 +15,11 @@ export {
 } from "./PostService.js";
 
 // Categories
-export { getAllCategories, createCategory } from "./CategoryService.js";
+export {
+  getAllCategories,
+  createCategory,
+  deleteCategory, // Added for Ticket #16 - Delete a Category
+} from "./CategoryService.js";
 
 // Comments
 export { getCommentsByPostId, createComment } from "./CommentService.js";


### PR DESCRIPTION
# Description

Added delete category functionality for Ticket #16. Admins can now delete a category from the category list with a confirmation dialog to prevent accidental deletions. The UI updates instantly after deletion without requiring a page refresh.

## Changes

- [ ] Bug fix  
- [X] New feature  

## Testing

Navigate to the Categories list
Click the trash icon on any category
Verify the confirm dialog appears
Click confirm — verify the category is removed from the list instantly
Repeat step 2, click cancel — verify the category is NOT removed and the dialog closes

## Notes

All users are currently treated as admins per instructor instructions. User permission enforcement is a future ticket.
