### PR TITLE
Added a User Profile Details View

### DIFF
--- a/src/components/posts/PostDetails.jsx
+++ b/src/components/posts/PostDetails.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 // useParams lets us read the :postId from the URL (e.g. /posts/5 → postId = "5")
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 // Custom service function we created in PostService.js to fetch a single post by ID
 import { getPostByIdExpandCategoryExpandUser } from "../../services";
 
@@ -91,11 +91,12 @@ export const PostDetails = () => {
         */}
         <nav className="level mb-5">
           {/* Author display name - uses optional chaining (?.) in case user data is missing */}
+          {/* Made authors name into a link to their profile */}
           <div className="level-left">
-            <div>
+            <Link to={`/users/${post.user_id}`} className="has-text-weight-semibold">
               <strong>By:</strong> {post.user?.first_name}{" "}
               {post.user?.last_name}
-            </div>
+            </Link>
           </div>
 
           {/* Buttons for the center */}

--- a/src/components/users/UserDetails.jsx
+++ b/src/components/users/UserDetails.jsx
@@ -1,0 +1,44 @@
+import { Button, Card, Container } from "../../design"
+import { Link, useParams } from "react-router-dom"
+import { useState, useEffect } from "react"
+import { getUserById } from "../../services"
+
+export const UserDetails = () => {
+
+    const {userId} = useParams()
+    const [author, setAuthor] = useState({})
+
+    useEffect(()=>{
+        getUserById(parseInt(userId)).then((fetchedAuthor) => {
+        setAuthor(fetchedAuthor)})
+    },[userId])
+
+    const formatDate = (dateString) => {
+        const date = new Date(dateString + 'T00:00:00');
+        return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+    };
+
+    return (
+        <Container>
+            <Card>
+                <div className="columns">
+                    <div className="column is-3">
+                        <img src={author.profile_image_url} alt={`${author.first_name} ${author.last_name}`} className="mb-4 rounded-full w-32 h-32 object-cover" />
+                        <p className="has-text-grey is-size-10 mb-2">{author.first_name} {author.last_name}</p>
+                    </div>
+                    <div className="column is-3">
+                        <h2 className="title">{author.username}</h2>
+                        <p><strong>Member Since:</strong> {formatDate(author.created_on)}</p>
+                        <p><strong>Email:</strong> {author.email}</p>
+                        <p><strong>Profile Type:</strong> {author.is_staff ? "Admin" : "Author"}</p>
+                        <Link to={`/users/${author.id}/posts`} className="has-text-link">View Posts (Coming Soon Ticket #35)</Link>
+                    </div>
+                    <div className="column is-3 has-text-right">
+                        <Button variant="primary" className="mb-4" title="Subscribe to this author(coming soon Ticket #31)">Subscribe</Button>
+                    </div>
+                </div>
+            </Card>
+        </Container>
+    )
+         
+  }

--- a/src/components/users/UserProfiles.jsx
+++ b/src/components/users/UserProfiles.jsx
@@ -1,6 +1,6 @@
 // Component for displaying all user profiles.
 import { useEffect, useState, useRef } from "react"
-import { useNavigate } from "react-router-dom"
+import { useNavigate, Link } from "react-router-dom"
 import { getAllUsers, getInactiveUsers, getActiveUsers, updateUser } from "../../services/index.js"
 import { Loading, PageHeader, Container, Card, ConfirmDialog, Button} from "../../design"
 import { useCurrentUser } from "../../context/CurrentUserContext.js"
@@ -139,7 +139,7 @@ if (!currentUser || !currentUser.is_staff) {
           {users.map((user) => (
             <tr key={user.id}>
               {/* Username */}
-              <td>{user.username}</td>
+              <td><Link to={`/users/${user.id}`}>{user.username}</Link></td>
 
               {/* User Name */}
               <td>

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -18,6 +18,7 @@ import { ButtonDemo } from "../design/bulma-reference/ButtonDemo";
 import { UserProfiles } from "../components/users/UserProfiles.jsx";
 import { TagList } from "../components/tags/TagList.jsx";
 import { NewTag } from "../components/tags/NewTag.jsx";
+import { UserDetails } from "../components/users/UserDetails.jsx";
 
 export const ApplicationViews = ({ token, setToken }) => {
   return (
@@ -42,6 +43,7 @@ export const ApplicationViews = ({ token, setToken }) => {
           <Route path="posts/:postId/comments" element={<PostComments />} />
           <Route path="tags" element={<TagList />} />
           <Route path="tags/new" element={<NewTag />} />
+          <Route path="users/:userId" element={<UserDetails />} />
           {/* Add more authenticated routes here */}
 
           {/* Staff-only routes */}


### PR DESCRIPTION
# Description

Added a `UserDetails` page that displays a public profile for any author, accessible by navigating to `/users/:userId`. The author's name in `PostDetails` and the username in `UserProfiles` are now clickable links that route to this new profile page.

## Changes

- [ ] Bug fix  
- [x] New feature

## Testing

1. Navigate to any post and click the author's name  — confirm it routes to `/users/:userId`
2. As an admin, navigate to the User Profiles table and click any username — confirm it routes to that user's profile page
3. On the `UserDetails` page, verify the profile image, name, username, email, member since (formatted as e.g. "March 3, 2026"), and profile type all render correctly
4. Confirm the "Subscribe" button appears in the top-right of the card (functionality coming soon — Ticket #31)
5. Confirm the "View Posts" link is present (coming soon — Ticket #35)

## Notes

- `formatDate()` appends `T00:00:00` to the date string before parsing to prevent timezone offset issues that can shift the displayed date by one day
- Subscribe and View Posts features are stubbed out pending Tickets #31 and #35