### PR TITLE
Jf/edit a tag 19

### DIFF
--- a/src/components/comments/EditCommentButton.jsx
+++ b/src/components/comments/EditCommentButton.jsx
@@ -4,35 +4,26 @@ import { getCommentById, editComment } from "../../services/CommentService";
 
 export const EditCommentButton = ({ icon, title, commentId, onUpdate }) => {
     const [comment, setComment] = useState(null);
-    const [loading, setLoading] = useState(true);
+    const [isOpen, setIsOpen] = useState(false); 
     const dialogRef = useRef(null);
 
-    // Function to open the dialog when the edit button is clicked
     const openDialog = () => {
-        dialogRef.current?.showModal();
-    };
-    
-    // This useEffect fetches the comment data when the component mounts or when commentId changes, so we have the latest content to edit
-    useEffect(() => {
         getCommentById(commentId).then(fetchedComment => {
             setComment(fetchedComment);
-            setLoading(false);
+            setIsOpen(true);
         }).catch(error => {
             console.error("Failed to fetch comment:", error);
-            setComment(null);
-            setLoading(false);
+            setComment(null);   
         });
-    }, [commentId]);
+    };
     
-    if (loading) {
-        return null;  
-    }   
-
-    if (!comment) {
-        return null;  
-    }   
-
-    // Handles the form submission to save the edited comment. It calls the editComment service and then triggers the onUpdate callback to refresh the comments list in the parent component, and finally closes the dialog.
+    useEffect(() => {
+        if (isOpen && dialogRef.current) {  
+        dialogRef.current?.showModal(); 
+        setIsOpen(false);
+        }           
+    }, [isOpen]);
+    
     const handleSubmit = async () => {
 
         const commentData = {
@@ -45,8 +36,7 @@ export const EditCommentButton = ({ icon, title, commentId, onUpdate }) => {
             author: comment.author
         };
         await editComment(commentId, commentData).then(() => {
-            getCommentById(commentId).then(setComment);
-            onUpdate?.(); // triggers parent to re-fetch
+            onUpdate?.(); 
             dialogRef.current?.close();
         }).catch(error => {
           console.error("Failed to update comment:", error);
@@ -55,11 +45,8 @@ export const EditCommentButton = ({ icon, title, commentId, onUpdate }) => {
 
     return (
         <>
-            {/* IconButton is a reusable component that takes props for icon and title. When clicked, it opens the dialog for editing the comment. */}
 
             <IconButton icon={icon} title={title} onClick={openDialog} />
-            
-            {/* ConfirmDialog is a reusable component that renders a <dialog> with customizable title, message, and confirm/cancel buttons. In this case, the message prop contains the form fields for editing the comment content and subject. When the user clicks "Save Changes", it calls handleSubmit to save the edits. */}
 
             <ConfirmDialog
                 dialogRef={dialogRef}
@@ -69,14 +56,14 @@ export const EditCommentButton = ({ icon, title, commentId, onUpdate }) => {
                     <span className="mb-2">Content:</span>
                     <textarea
                         className="textarea mb-2"
-                        value={comment.content}
+                        value={comment?.content ?? ""}
                         onChange={(e) => setComment({...comment, content: e.target.value})}
                         rows={1}
                     />
                     <span className="mb-2">Subject:</span>
                     <textarea
                         className="textarea mb-2"
-                        value={comment.subject || ""}
+                        value={comment?.subject ?? ""}
                         onChange={(e) => setComment({...comment, subject: e.target.value})}
                         rows={1}
                     />

--- a/src/components/tags/EditTagButton.jsx
+++ b/src/components/tags/EditTagButton.jsx
@@ -1,54 +1,46 @@
 import { IconButton, ConfirmDialog } from "../../design";
 import { useState, useEffect, useRef } from "react";
-import { getTagById, editTag } from "../../services/TagService";        
+import { getTagById, editTag } from "../../services";        
 
 
 export const EditTagButton = ({ icon, title, tagId, onUpdate }) => {
 
     const [tag, setTag] = useState(null);
-    const [loading, setLoading] = useState(true);
+    const [isOpen, setIsOpen] = useState(false); //This state tracks whether the edit dialog should be open, and triggers the useEffect to show the dialog when set to true
     const dialogRef = useRef(null);
 
-    // Function to open the dialog when the edit button is clicked
+    // Function to open the dialog when the edit button is clicked. Tag data is fetched here so edit buttons will display on immediately upon initial render without waiting for all tag data to load.
     const openDialog = () => {
-        dialogRef.current?.showModal();
-    };
-    
-    // This useEffect fetches the tag data when the component mounts or when tagId changes, so we have the latest content to edit
-    useEffect(() => {
+        
         getTagById(tagId).then(fetchedTag => {
             setTag(fetchedTag);
-            setLoading(false);
+            setIsOpen(true);
         }).catch(error => {
             console.error("Failed to fetch tag:", error);
             setTag(null);
-            setLoading(false);
         });
-    }, [tagId]);
+    };
     
-    if (loading) {
-        return null;  
-    }   
-
-    if (!tag) {
-        return null;  
-    }   
+    // This useEffect fetches the tag data when the component mounts. It listens for changes to the isOpen state to trigger the dialog to open when the edit button is clicked.
+    useEffect(() => {
+        if (isOpen && dialogRef.current) {  
+        dialogRef.current?.showModal(); // Show the dialog when isOpen becomes true
+        setIsOpen(false); // resets the isOpen state to false after showing the dialog
+        }
+    }, [isOpen]);
+    
+   
 
     // Handles the form submission to save the edited tag. It calls the editTag service and then triggers the onUpdate callback to refresh the tags list in the parent component, and finally closes the dialog.
     const handleSubmit = async () => {
-
-        const tagData = {
-            id: tag.id,
-            label: tag.label
-        };
+        const tagData = { id: tag.id, label: tag.label };
         await editTag(tagId, tagData).then(() => {
-            getTagById(tagId).then(setTag);
-            onUpdate?.(); // triggers parent to re-fetch
+            onUpdate?.();
             dialogRef.current?.close();
         }).catch(error => {
-          console.error("Failed to update tag:", error);
+            console.error("Failed to update tag:", error);
         });
-      };    
+    };   
     
 
     return (
@@ -63,7 +55,7 @@ export const EditTagButton = ({ icon, title, tagId, onUpdate }) => {
                     <span className="mb-2">Content:</span>
                     <textarea
                         className="textarea mb-2"
-                        value={tag.label}
+                        value={tag?.label ?? ""} // Use optional chaining to handle the case when tag is null (initial render)
                         onChange={(e) => setTag({...tag, label: e.target.value})}
                         rows={1}
                     />

--- a/src/components/tags/EditTagButton.jsx
+++ b/src/components/tags/EditTagButton.jsx
@@ -1,0 +1,81 @@
+import { IconButton, ConfirmDialog } from "../../design";
+import { useState, useEffect, useRef } from "react";
+import { getTagById, editTag } from "../../services/TagService";        
+
+
+export const EditTagButton = ({ icon, title, tagId, onUpdate }) => {
+
+    const [tag, setTag] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const dialogRef = useRef(null);
+
+    // Function to open the dialog when the edit button is clicked
+    const openDialog = () => {
+        dialogRef.current?.showModal();
+    };
+    
+    // This useEffect fetches the tag data when the component mounts or when tagId changes, so we have the latest content to edit
+    useEffect(() => {
+        getTagById(tagId).then(fetchedTag => {
+            setTag(fetchedTag);
+            setLoading(false);
+        }).catch(error => {
+            console.error("Failed to fetch tag:", error);
+            setTag(null);
+            setLoading(false);
+        });
+    }, [tagId]);
+    
+    if (loading) {
+        return null;  
+    }   
+
+    if (!tag) {
+        return null;  
+    }   
+
+    // Handles the form submission to save the edited tag. It calls the editTag service and then triggers the onUpdate callback to refresh the tags list in the parent component, and finally closes the dialog.
+    const handleSubmit = async () => {
+
+        const tagData = {
+            id: tag.id,
+            label: tag.label
+        };
+        await editTag(tagId, tagData).then(() => {
+            getTagById(tagId).then(setTag);
+            onUpdate?.(); // triggers parent to re-fetch
+            dialogRef.current?.close();
+        }).catch(error => {
+          console.error("Failed to update tag:", error);
+        });
+      };    
+    
+
+    return (
+        <>
+        <IconButton icon={icon} title={title} onClick={openDialog} />
+        
+        <ConfirmDialog
+            dialogRef={dialogRef}
+            title="Edit Tag"
+            message={
+                    <>
+                    <span className="mb-2">Content:</span>
+                    <textarea
+                        className="textarea mb-2"
+                        value={tag.label}
+                        onChange={(e) => setTag({...tag, label: e.target.value})}
+                        rows={1}
+                    />
+                    </>
+                }
+            confirmText="Save Changes"
+            confirmColor="is-primary"
+            onConfirm={handleSubmit}
+            onCancel={() => dialogRef.current?.close()}
+            
+        />
+
+    </>
+    );
+};  

--- a/src/components/tags/NewTag.jsx
+++ b/src/components/tags/NewTag.jsx
@@ -1,7 +1,7 @@
 //Component for a form to create a new tag and submit it to the API
 
 import { useState } from "react";
-import { createTag } from "../../services/TagService";
+import { createTag } from "../../services";
 import { useNavigate } from "react-router-dom";
 import { Container, Form, FormField, PageHeader } from "../../design";
 

--- a/src/components/tags/TagList.jsx
+++ b/src/components/tags/TagList.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate} from "react-router-dom";
-import { getAllTags } from "../../services/TagService";
+import { getAllTags } from "../../services";
 import { Button, Container, Loading, PageHeader, IconButton, Card} from "../../design";
 import { useCurrentUser } from "../../context/CurrentUserContext";
 import { EditTagButton } from "./EditTagButton";

--- a/src/components/tags/TagList.jsx
+++ b/src/components/tags/TagList.jsx
@@ -3,6 +3,7 @@ import { useNavigate} from "react-router-dom";
 import { getAllTags } from "../../services/TagService";
 import { Button, Container, Loading, PageHeader, IconButton, Card} from "../../design";
 import { useCurrentUser } from "../../context/CurrentUserContext";
+import { EditTagButton } from "./EditTagButton";
 
 export const TagList = () => {
     const { currentUser } = useCurrentUser();
@@ -11,15 +12,19 @@ export const TagList = () => {
     const [tags, setTags] = useState([]);
     const [loading, setLoading] = useState(true);
 
-    useEffect(() => {
+    const getAndSetTags = () => {
         getAllTags().then(fetchedTags => {
             setTags(fetchedTags);
             setLoading(false);
-        }).catch(error => {
+        }       ).catch(error => {
             console.error("Failed to fetch tags:", error);
             setTags([]);
             setLoading(false);
         });
+    };  
+
+    useEffect(() => {
+        getAndSetTags();
     }, []);
 
     if (!currentUser || !currentUser.is_staff) {
@@ -45,14 +50,15 @@ export const TagList = () => {
                                    {/* Left: icon buttons */}
                                    <div className="media-left">
                                      <div className="buttons are-small">
-                                       <IconButton
-                                         icon="gear"
-                                         title="Edit category (coming soon)"
-                                         onClick={() => {}}
-                                       />
+                                       <EditTagButton
+                                          icon="gear"
+                                          title="Edit tag"
+                                          tagId={tag.id}
+                                          onUpdate={getAndSetTags}
+                                          />
                                        <IconButton
                                          icon="trash"
-                                         title="Delete category (coming soon)"
+                                         title="Delete tag"
                                          onClick={() => {}}
                                        />
                                      </div>
@@ -63,7 +69,6 @@ export const TagList = () => {
                                      <div className="content">
                                        <p className="mb-0">
                                          <span className="has-text-weight-semibold">{tag.label}</span>
-                                         <hr className="my-2" />
                                        </p>
                                      </div>
                                    </div>

--- a/src/services/TagService.js
+++ b/src/services/TagService.js
@@ -8,3 +8,14 @@ export const getAllTags = () => {
 export const createTag = (tag) => {
     return postJson("/tags", tag);
 }
+
+export const getTagById = (id) => {
+    return fetchJson(`/tags/${id}`);
+}
+
+export const editTag = (id, updatedTag) => {
+    return fetchJson(`/tags/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(updatedTag),
+    });
+}   

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -29,3 +29,6 @@ export { getAllReactions } from "./ReactionService.js";
 
 // PostReactions
 export { getAllPostReactions, getPostReactionsByPostId, updateOrCreatePostReaction } from "./PostReactionService.js";
+
+//Tags
+export { getAllTags, createTag, getTagById, editTag } from "./TagService.js";


### PR DESCRIPTION
Edit a Tag Client

# Description

Implemented the Edit Tag feature, replacing the placeholder "Edit tag (coming soon)" button with a fully functional EditTagButton component. The new component fetches the current tag data, displays it in a dialog with an editable textarea, and saves changes via a PUT request. After saving, the tag list refreshes automatically.


## Changes

- [ ] Bug fix  
- [x] New feature  


## Testing

1. Log in "as Staff" - Navigate to the Tag Manager tab
2. Confirm Edit (gear) buttons appear on page load
3. Click an Edit button — confirm the dialog opens with the correct tag data pre-filled
4. Edit the tag label and click Save Changes — confirm the list refreshes with the updated value
5. Find the tag in the server side db.sqlite3 file and confirm the edit has registered there



## Notes


- Tag and Comment services are now exported through the shared `services/index.js` barrel file for consistency with the rest of the codebase
- `ConfirmDialog` is always mounted but guarded with `tag?.label ?? ""` to avoid a null crash on initial render before any fetch has run



