### PR TITLE
Ticket #18 Add delete tag functionality with confirm dialog

### DIFF
--- a/src/components/tags/TagList.jsx
+++ b/src/components/tags/TagList.jsx
@@ -1,79 +1,120 @@
-import { useEffect, useState } from "react";
-import { useNavigate} from "react-router-dom";
-import { getAllTags } from "../../services/TagService";
-import { Button, Container, Loading, PageHeader, IconButton, Card} from "../../design";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+//Ticket #18 Added deleteTag import
+import { getAllTags, deleteTag } from "../../services/TagService";
+import {
+  Button,
+  Container,
+  Loading,
+  PageHeader,
+  IconButton,
+  Card,
+  ConfirmDialog,
+} from "../../design";
 import { useCurrentUser } from "../../context/CurrentUserContext";
 
 export const TagList = () => {
-    const { currentUser } = useCurrentUser();
-    const navigate = useNavigate();
+  const { currentUser } = useCurrentUser();
+  const navigate = useNavigate();
 
-    const [tags, setTags] = useState([]);
-    const [loading, setLoading] = useState(true);
+  const [tags, setTags] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedTagId, setSelectedTagId] = useState(null);
+  const dialogRef = useRef(null);
 
-    useEffect(() => {
-        getAllTags().then(fetchedTags => {
-            setTags(fetchedTags);
-            setLoading(false);
-        }).catch(error => {
-            console.error("Failed to fetch tags:", error);
-            setTags([]);
-            setLoading(false);
-        });
-    }, []);
+  useEffect(() => {
+    getAllTags()
+      .then((fetchedTags) => {
+        setTags(fetchedTags);
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error("Failed to fetch tags:", error);
+        setTags([]);
+        setLoading(false);
+      });
+  }, []);
 
-    if (!currentUser || !currentUser.is_staff) {
-    navigate("/access-denied", { replace: true })
-    return null
+  if (!currentUser || !currentUser.is_staff) {
+    navigate("/access-denied", { replace: true });
+    return null;
   }
 
-    if (loading) {
-        return <Loading />;
-    }
+  if (loading) {
+    return <Loading />;
+  }
 
-    if (!tags.length) {
-        return <p>There are no tags available. Click the button below to start adding new tags.</p>;
-    }
-
+  if (!tags.length) {
     return (
-        <Container>
-            <PageHeader title="Tags" />
-               
-                    {tags.map(tag => (
-                        <Card key={tag.id}>
-                                 <article className="media">
-                                   {/* Left: icon buttons */}
-                                   <div className="media-left">
-                                     <div className="buttons are-small">
-                                       <IconButton
-                                         icon="gear"
-                                         title="Edit category (coming soon)"
-                                         onClick={() => {}}
-                                       />
-                                       <IconButton
-                                         icon="trash"
-                                         title="Delete category (coming soon)"
-                                         onClick={() => {}}
-                                       />
-                                     </div>
-                                   </div>
-                       
-                                   {/* Main: tag label */}
-                                   <div className="media-content">
-                                     <div className="content">
-                                       <p className="mb-0">
-                                         <span className="has-text-weight-semibold">{tag.label}</span>
-                                         <hr className="my-2" />
-                                       </p>
-                                     </div>
-                                   </div>
-                                 </article>
-                        </Card>
-                    ))}
-                <div className="mt-4 mb-4">
-                    <Button color="primary" onClick={() => navigate("/tags/new")}>Create a Tag</Button>
-                </div>
-        </Container>
- 
-    )
-}
+      <p>
+        There are no tags available. Click the button below to start adding new
+        tags.
+      </p>
+    );
+  }
+
+  const handleConfirmDelete = () => {
+    deleteTag(selectedTagId).then((response) => {
+      const updatedTags = tags.filter((tag) => tag.id !== selectedTagId);
+      setTags(updatedTags);
+    });
+    dialogRef.current?.close();
+    setSelectedTagId(null);
+  };
+
+  return (
+    <Container>
+      <PageHeader title="Tags" />
+
+      <ConfirmDialog
+        dialogRef={dialogRef}
+        title={"Confirm Tag Delete"}
+        message={"Are you sure you want to delete this?"}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => {
+          dialogRef.current?.close();
+          setSelectedTagId(null);
+        }}
+      />
+      {tags.map((tag) => (
+        <Card key={tag.id}>
+          <article className="media">
+            {/* Left: icon buttons */}
+            <div className="media-left">
+              <div className="buttons are-small">
+                <IconButton
+                  icon="gear"
+                  title="Edit tag (coming soon)"
+                  onClick={() => {}}
+                />
+                <IconButton
+                  icon="trash"
+                  title="Delete tag (coming soon)"
+                  onClick={() => {
+                    setSelectedTagId(tag.id);
+                    dialogRef.current?.showModal();
+                  }}
+                />
+              </div>
+            </div>
+
+            {/* Main: tag label */}
+            <div className="media-content">
+              <div className="content">
+                <p className="mb-0">
+                  <span className="has-text-weight-semibold">{tag.label}</span>
+                  <hr className="my-2" />
+                </p>
+              </div>
+            </div>
+          </article>
+        </Card>
+      ))}
+      <div className="mt-4 mb-4">
+        <Button color="primary" onClick={() => navigate("/tags/new")}>
+          Create a Tag
+        </Button>
+      </div>
+    </Container>
+  );
+};

--- a/src/services/TagService.js
+++ b/src/services/TagService.js
@@ -1,10 +1,14 @@
-import { fetchJson, postJson } from "./apiSettings";
+import { fetchJson, postJson, deleteJson } from "./apiSettings";
 
 // Function to get all tags from the API Ticket #10
 export const getAllTags = () => {
-    return fetchJson("/tags");
-}
+  return fetchJson("/tags");
+};
 
 export const createTag = (tag) => {
-    return postJson("/tags", tag);
-}
+  return postJson("/tags", tag);
+};
+// Ticket #18 function that deletes Tags from the API
+export const deleteTag = (id) => {
+  return deleteJson(`/tags/${id}`);
+};

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,5 +1,11 @@
 // Users
-export { getUserById, getAllUsers, updateUser, getActiveUsers, getInactiveUsers } from "./UserService.js";
+export {
+  getUserById,
+  getAllUsers,
+  updateUser,
+  getActiveUsers,
+  getInactiveUsers,
+} from "./UserService.js";
 
 // Posts
 export {
@@ -28,4 +34,11 @@ export { getCommentsByPostId, createComment } from "./CommentService.js";
 export { getAllReactions } from "./ReactionService.js";
 
 // PostReactions
-export { getAllPostReactions, getPostReactionsByPostId, updateOrCreatePostReaction } from "./PostReactionService.js";
+export {
+  getAllPostReactions,
+  getPostReactionsByPostId,
+  updateOrCreatePostReaction,
+} from "./PostReactionService.js";
+
+// Tags
+export { getAllTags, createTag, deleteTag } from "./TagService.js";


### PR DESCRIPTION
# Description

Added delete tag functionality for Ticket #18. Staff users can now delete a tag from the tag list with a confirmation dialog to prevent accidental deletions. The UI updates instantly after deletion without requiring a page refresh.

## Changes

- [ ] Bug fix  
- [X] New feature  

## Testing

Log in as a staff user and navigate to the Tags list
Click the trash icon on any tag
Verify the confirm dialog appears
Click confirm — verify the tag is removed from the list instantly
Repeat step 2, click cancel — verify the tag is NOT removed and the dialog closes

## Notes

The Python server needs a DELETE /tags/<id> endpoint for this to work fully. The client-side implementation is complete.
