### PR TITLE
Ticket #22 - Add delete comment functionality

### DIFF
--- a/src/components/categories/CategoriesList.jsx
+++ b/src/components/categories/CategoriesList.jsx
@@ -93,7 +93,7 @@ export const CategoriesList = () => {
                 />
                 <IconButton
                   icon="trash"
-                  title="Delete category (coming soon)"
+                  title="Delete category"
                   onClick={() => {
                     setSelectedCategoryId(category.id);
                     dialogRef.current?.showModal();

--- a/src/components/comments/CommentList.jsx
+++ b/src/components/comments/CommentList.jsx
@@ -1,11 +1,14 @@
 // Ticket #21 - View Comments list page for a given post
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams } from "react-router-dom";
-import { getPostById, getCommentsByPostId } from "../../services";
-import { Container, IconButton } from "../../design";
+import {
+  getPostById,
+  getCommentsByPostId,
+  deleteComment,
+} from "../../services";
+import { Container, IconButton, ConfirmDialog } from "../../design";
 import { useCurrentUser } from "../../context/CurrentUserContext";
 import { EditCommentButton } from "./EditCommentButton";
-
 
 export const CommentList = () => {
   const { postId } = useParams();
@@ -13,6 +16,8 @@ export const CommentList = () => {
 
   const [post, setPost] = useState(null);
   const [comments, setComments] = useState(null);
+  const [selectedCommentId, setSelectedCommentId] = useState(null);
+  const dialogRef = useRef(null);
 
   //Moved the comments fetching logic into a separate function so it can be called both on initial load and after posting a new comment to refresh the list.
 
@@ -29,12 +34,25 @@ export const CommentList = () => {
     // Fetch #1: get the post so we can display its title and build the back link
     getPostById(postId).then(setPost);
     // Fetch #2: get all comments for this post, then sort before storing
-    getAndSetComments();    
+    getAndSetComments();
   }, [postId, getAndSetComments]); // Re-run this effect if postId changes or comments are updated (e.g. after posting a new comment)
 
   // Guard: if either API call hasn't finished yet, both will still be null
   // Returning early here prevents the JSX below from trying to read data that doesn't exist yet
   if (!post || !comments) return <p>Loading...</p>;
+
+  // Ticket #22 - handles confirmed deletion: calls the API, then filters the deleted comment out of state so the UI updates instantly without a page refresh
+  const handleConfirmDelete = () => {
+    deleteComment(selectedCommentId).then((response) => {
+      // Filter out the deleted comment from local state so the list updates immediately
+      const updatedComments = comments.filter(
+        (comment) => comment.id !== selectedCommentId,
+      );
+      setComments(updatedComments);
+    });
+    dialogRef.current?.close(); //This is setup to close the modal and not navigate to another page.
+    setSelectedCommentId(null); //Good safeguard to help prevent bugs.
+  };
 
   return (
     <Container>
@@ -46,54 +64,67 @@ export const CommentList = () => {
 
       {/* .map() loops over the sorted comments array and returns JSX for each one */}
       {/* key={comment.id} is required by React to track list items efficiently */}
+
+      {/* Ticket #22 - confirmation dialog rendered once, opened via dialogRef.current.showModal() when trash is clicked */}
+      <ConfirmDialog
+        dialogRef={dialogRef}
+        title={"Confirm Comment Delete"}
+        message={"Are you sure you want to delete this?"}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => {
+          dialogRef.current?.close();
+          setSelectedCommentId(null);
+        }} //The onCancel is setup to make sure after any cancels that the state is set to null, so that there is no accidental deletion of other comments.
+      />
       <div className="columns is-multiline">
-      {comments.map((comment) => (
-        <div className="column is-half mb-6" key={comment.id}>
-          
-          <article className="message is-info">
-         
-
-          
-
-          {/* comment.user is the expanded user object from &_expand=user in CommentService */}
-          <div className="message-header">
-            <span><strong className="has-text-left">Comment By:</strong> {comment.author}</span>
-              <div className="buttons are-small">
-                {comment.author_id === currentUser?.id && (
-                  <>
-                    {/* Replaced empty Icon Button with function EditCommentButton component. */}
-                    <EditCommentButton
-                      icon="gear"
-                      title="Edit Comment"
-                      commentId={comment.id}
-                      // onUpdate is a callback prop that EditCommentButton will call after successfully saving edits, which triggers this parent component to re-fetch the comments list and show the updated content without needing a full page refresh.
-                      onUpdate={getAndSetComments}/>
-                    <IconButton
-                      icon="trash"
-                      title="Delete comment (coming soon)"
-                      onClick={() => {}}
-                    /> 
-                  </> 
-                )}
+        {comments.map((comment) => (
+          <div className="column is-half mb-6" key={comment.id}>
+            <article className="message is-info">
+              {/* comment.user is the expanded user object from &_expand=user in CommentService */}
+              <div className="message-header">
+                <span>
+                  <strong className="has-text-left">Comment By:</strong>{" "}
+                  {comment.author}
+                </span>
+                <div className="buttons are-small">
+                  {comment.author_id === currentUser?.id && (
+                    <>
+                      {/* Replaced empty Icon Button with function EditCommentButton component. */}
+                      <EditCommentButton
+                        icon="gear"
+                        title="Edit Comment"
+                        commentId={comment.id}
+                        // onUpdate is a callback prop that EditCommentButton will call after successfully saving edits, which triggers this parent component to re-fetch the comments list and show the updated content without needing a full page refresh.
+                        onUpdate={getAndSetComments}
+                      />
+                      <IconButton
+                        icon="trash"
+                        title="Delete comment"
+                        onClick={() => {
+                          setSelectedCommentId(comment.id);
+                          dialogRef.current?.showModal();
+                        }}
+                      />
+                    </>
+                  )}
+                </div>
               </div>
-              
+              {/* Full body/content of the comment */}
+              <div className="message-body">
+                <strong>Content:</strong> {comment.content}
+                {/* Formatted as MM/DD/YYYY using toLocaleDateString, same pattern as PostDetails */}
+                <div>
+                  <strong>Date:</strong>{" "}
+                  {new Date(comment.created_on).toLocaleDateString("en-US")}
+                </div>
+                <div>
+                  {/* Subject of the comment */}
+                  <strong>Subject:</strong> {comment.subject}
+                </div>
+              </div>
+            </article>
           </div>
-          {/* Full body/content of the comment */}
-          <div className="message-body">
-            <strong>Content:</strong> {comment.content}
-            {/* Formatted as MM/DD/YYYY using toLocaleDateString, same pattern as PostDetails */}
-            <div>
-              <strong>Date:</strong>{" "}
-              {new Date(comment.created_on).toLocaleDateString("en-US")}
-            </div>
-           <div>
-            {/* Subject of the comment */}
-            <strong>Subject:</strong> {comment.subject}
-          </div>
-          </div>
-          </article>
-        </div>
-      ))}
+        ))}
       </div>
     </Container>
   );

--- a/src/services/CommentService.js
+++ b/src/services/CommentService.js
@@ -1,4 +1,4 @@
-import { fetchJson, postJson, putJson } from "./apiSettings";
+import { fetchJson, postJson, putJson, deleteJson } from "./apiSettings";
 
 // expand supports: "user", "author", and "post"
 // "author" is an alias for "user"
@@ -18,10 +18,9 @@ export function getCommentsByPostId(postId, ...expand) {
   normalized.forEach((e) => {
     params.append("_expand", e);
   });
-  
+
   return fetchJson(`/comments?${params.toString()}`);
 }
-
 
 export function createComment(comment) {
   return postJson("/comments", comment);
@@ -34,3 +33,8 @@ export function editComment(commentId, commentData) {
 export function getCommentById(id) {
   return fetchJson(`/comments/${id}?_expand=user`);
 }
+
+// Ticket #22 - Delete a Comment: sends DELETE request to remove a comment by id
+export const deleteComment = (id) => {
+  return deleteJson(`/comments/${id}`);
+};

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,5 +1,11 @@
 // Users
-export { getUserById, getAllUsers, updateUser, getActiveUsers, getInactiveUsers } from "./UserService.js";
+export {
+  getUserById,
+  getAllUsers,
+  updateUser,
+  getActiveUsers,
+  getInactiveUsers,
+} from "./UserService.js";
 
 // Posts
 export {
@@ -22,10 +28,18 @@ export {
 } from "./CategoryService.js";
 
 // Comments
-export { getCommentsByPostId, createComment } from "./CommentService.js";
+export {
+  getCommentsByPostId,
+  createComment,
+  deleteComment,
+} from "./CommentService.js";
 
 // Reactions
 export { getAllReactions } from "./ReactionService.js";
 
 // PostReactions
-export { getAllPostReactions, getPostReactionsByPostId, updateOrCreatePostReaction } from "./PostReactionService.js";
+export {
+  getAllPostReactions,
+  getPostReactionsByPostId,
+  updateOrCreatePostReaction,
+} from "./PostReactionService.js";


### PR DESCRIPTION
# Description

Ticket #22 - Added delete comment functionality to the CommentList page. Users can now click the trash icon on their own comments, confirm via a dialog, and the comment is removed from the list instantly without a page refresh.

## Changes

- [x] Bug fix
- [x] New feature

- Fixed `deleteComment` in `CommentService.js` was pointing to `/categories/${id}`, corrected to `/comments/${id}`
- Added `ConfirmDialog` import and rendered it in `CommentList.jsx`
- Wired up the trash `IconButton` to set `selectedCommentId` and open the confirm dialog
- `handleConfirmDelete` calls `deleteComment`, filters the deleted comment out of local state, closes the dialog, and resets `selectedCommentId`

## Testing

1. Navigate to a post’s comment list
2. Click the trash icon on a comment you authored
3. Confirm the dialog comment should disappear immediately without a page refresh
4. Click trash, then cancel no comment should be deleted

## Notes

- Only the comment’s author sees the trash and edit buttons (`comment.author_id === currentUser?.id`)
- `editComment` and `getCommentById` exist in `CommentService.js` but are not yet exported from `services/index.js` teammate is handling that as part of their ticket
