### PR TITLE
Adding and Removing a Tag from a Post (Tickets #10 and #20)

### DIFF
--- a/src/components/posts/EditPost.jsx
+++ b/src/components/posts/EditPost.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { updatePost, getAllCategories, getPostById, getAllTags} from "../../services"
+import { updatePost, getAllCategories, getPostById } from "../../services"
 import { useCurrentUser } from "../../context/CurrentUserContext.js"
 import { useParams, useNavigate } from "react-router-dom"
 import { Container, PageHeader, Loading } from "../../design"
@@ -10,7 +10,6 @@ export const EditPost = () => {
   const { currentUser } = useCurrentUser()
   const [post, setPost] = useState(null)
   const [categories, setCategories] = useState([])
-  const [tags, setTags] = useState([])
   const [loading, setLoading] = useState(true)
   const [submitError, setSubmitError] = useState("")
   const navigate = useNavigate()
@@ -18,8 +17,8 @@ export const EditPost = () => {
   useEffect(() => {
     if (!currentUser) return
 
-    Promise.all([getPostById(postId), getAllCategories(), getAllTags()])
-      .then(([fetchedData, fetchedCategories, fetchedTags]) => {
+    Promise.all([getPostById(postId), getAllCategories()])
+      .then(([fetchedData, fetchedCategories]) => {
         const fetchedPost = Array.isArray(fetchedData)
           ? fetchedData.find((p) => p.id === parseInt(postId))
           : fetchedData
@@ -30,7 +29,6 @@ export const EditPost = () => {
         }
 
         setPost(fetchedPost)
-        setTags(fetchedTags)
         setCategories(fetchedCategories)
         setLoading(false)
       })
@@ -109,8 +107,6 @@ export const EditPost = () => {
             submitError={submitError}
             submitLabel="Save Changes"
             showImageUrl={false}
-            showTags={true}
-            tags={tags}
           />
         </div>
       </div>

--- a/src/components/posts/EditPostTagsDialog.jsx
+++ b/src/components/posts/EditPostTagsDialog.jsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ConfirmDialog, Tag, Button, Loading } from "../../design";
+import {
+  getAllTags,
+  getTagsByPostId,
+  addTagToPost,
+  removeTagFromPost,
+  createTag,
+} from "../../services";
+
+export const EditPostTagsDialog = ({
+  post,
+  canAddTags = false,
+  canCreateTags = false,
+  canRemoveTags = false,
+  onClose,
+  onUpdated,
+}) => {
+  const dialogRef = useRef(null);
+
+  const [loading, setLoading] = useState(true);
+  const [postTags, setPostTags] = useState([]);
+  const [allTags, setAllTags] = useState([]);
+  const [selectedTagId, setSelectedTagId] = useState("");
+  const [newTagLabel, setNewTagLabel] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [notification, setNotification] = useState("");
+
+  // Open dialog + fetch needed data
+  useEffect(() => {
+    if (!post?.id) return;
+
+    const loadDialogData = async () => {
+      setLoading(true);
+
+      try {
+        const [fetchedPostTags, fetchedAllTags] = await Promise.all([
+          getTagsByPostId(post.id),
+          getAllTags(),
+        ]);
+
+        setPostTags(fetchedPostTags ?? []);
+        setAllTags(fetchedAllTags ?? []);
+      } catch (error) {
+        console.error("Failed to load tag editor data:", error);
+        setPostTags([]);
+        setAllTags([]);
+        setNotification("Failed to load tags.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadDialogData();
+  }, [post?.id]);
+
+  // Show the dialog after mount
+  useEffect(() => {
+    dialogRef.current?.showModal();
+  }, []);
+
+  // IDs already attached to this post
+  const attachedTagIds = useMemo(() => {
+    return new Set(postTags.map((tag) => tag.id));
+  }, [postTags]);
+
+  // Only show tags that are not already attached
+  const availableTagsToAdd = useMemo(() => {
+    return allTags.filter((tag) => !attachedTagIds.has(tag.id));
+  }, [allTags, attachedTagIds]);
+
+  const handleRemoveTag = async (tagId) => {
+    if (!canRemoveTags) return;
+
+    setIsSaving(true);
+    setNotification("");
+
+    try {
+      await removeTagFromPost(post.id, tagId);
+
+      setPostTags((current) => current.filter((tag) => tag.id !== tagId));
+      setNotification("Tag removed.");
+    } catch (error) {
+      console.error("Failed to remove tag from post:", error);
+      setNotification("Failed to remove tag.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleAddExistingTag = async () => {
+    if (!canAddTags || !selectedTagId) return;
+
+    setIsSaving(true);
+    setNotification("");
+
+    try {
+      const tagId = parseInt(selectedTagId);
+
+      await addTagToPost(post.id, tagId);
+
+      const addedTag = allTags.find((tag) => tag.id === tagId);
+      if (addedTag) {
+        setPostTags((current) => [...current, addedTag]);
+      }
+
+      setSelectedTagId("");
+      setNotification("Tag added.");
+    } catch (error) {
+      console.error("Failed to add tag to post:", error);
+      setNotification("Failed to add tag.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCreateAndAddTag = async () => {
+    if (!canCreateTags || !newTagLabel.trim()) return;
+
+    setIsSaving(true);
+    setNotification("");
+
+    try {
+      // Create the new tag first
+      const createdTag = await createTag({ label: newTagLabel.trim() });
+
+      // Depending on your service, createdTag may already be the tag object
+      // with id + label. If not, you may need to re-fetch all tags here.
+      const usableTag = createdTag;
+
+      await addTagToPost(post.id, usableTag.id);
+
+      setAllTags((current) => [...current, usableTag]);
+      setPostTags((current) => [...current, usableTag]);
+      setNewTagLabel("");
+      setNotification("New tag created and added.");
+    } catch (error) {
+      console.error("Failed to create and add tag:", error);
+      setNotification("Failed to create and add tag.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDone = () => {
+    dialogRef.current?.close();
+    onUpdated?.();
+  };
+
+  const handleCancel = () => {
+    dialogRef.current?.close();
+    onClose?.();
+  };
+
+  return (
+    <ConfirmDialog
+      dialogRef={dialogRef}
+      title={`Edit Tags for "${post?.title ?? "Post"}"`}
+      message={
+        <div>
+          {loading ? (
+            <Loading />
+          ) : (
+            <>
+              {/* Existing tags */}
+              <div className="mb-4">
+                <p className="has-text-weight-semibold mb-2">Current Tags</p>
+
+                {postTags.length ? (
+                  <div className="is-flex is-flex-direction-column" style={{ gap: "0.75rem" }}>
+                    {postTags.map((tag) => (
+                      <div
+                        key={tag.id}
+                        className="is-flex is-justify-content-space-between is-align-items-center"
+                        style={{ gap: "0.75rem" }}
+                      >
+                        <Tag color="warning" light rounded>
+                          {tag.label}
+                        </Tag>
+
+                        {canRemoveTags ? (
+                          <Button
+                            color="danger"
+                            light
+                            disabled={isSaving}
+                            onClick={() => handleRemoveTag(tag.id)}
+                          >
+                            Remove
+                          </Button>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="is-size-7 has-text-grey">This post has no tags.</p>
+                )}
+              </div>
+
+              {/* Add existing tag */}
+              {canAddTags ? (
+                <div className="mb-4">
+                  <p className="has-text-weight-semibold mb-2">Add Existing Tag</p>
+
+                  {availableTagsToAdd.length ? (
+                    <>
+                      <div className="field has-addons">
+                        <div className="control is-expanded">
+                          <div className="select is-fullwidth">
+                            <select
+                              value={selectedTagId}
+                              onChange={(e) => setSelectedTagId(e.target.value)}
+                              disabled={isSaving}
+                            >
+                              <option value="">Select a tag</option>
+                              {availableTagsToAdd.map((tag) => (
+                                <option key={tag.id} value={tag.id}>
+                                  {tag.label}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+
+                        <div className="control">
+                          <Button
+                            color="primary"
+                            disabled={isSaving || !selectedTagId}
+                            onClick={handleAddExistingTag}
+                          >
+                            Add
+                          </Button>
+                        </div>
+                      </div>
+                    </>
+                  ) : (
+                    <p className="is-size-7 has-text-grey">
+                      No additional existing tags are available to add.
+                    </p>
+                  )}
+                </div>
+              ) : null}
+
+              {/* Create and add new tag */}
+              {canCreateTags ? (
+                <div className="mb-3">
+                  <p className="has-text-weight-semibold mb-2">Create New Tag</p>
+
+                  <div className="field has-addons">
+                    <div className="control is-expanded">
+                      <input
+                        className="input"
+                        type="text"
+                        placeholder="Enter new tag label"
+                        value={newTagLabel}
+                        onChange={(e) => setNewTagLabel(e.target.value)}
+                        disabled={isSaving}
+                      />
+                    </div>
+
+                    <div className="control">
+                      <Button
+                        color="primary"
+                        disabled={isSaving || !newTagLabel.trim()}
+                        onClick={handleCreateAndAddTag}
+                      >
+                        Create + Add
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {notification ? (
+                <p className="help mt-2">{notification}</p>
+              ) : null}
+            </>
+          )}
+        </div>
+      }
+      confirmText="Done"
+      confirmColor="is-primary"
+      onConfirm={handleDone}
+      onCancel={handleCancel}
+    />
+  );
+};

--- a/src/components/posts/EditPostTagsDialog.jsx
+++ b/src/components/posts/EditPostTagsDialog.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ConfirmDialog, Tag, Button, Loading } from "../../design";
 import {
   getAllTags,
@@ -25,12 +25,14 @@ export const EditPostTagsDialog = ({
   const [newTagLabel, setNewTagLabel] = useState("");
   const [isSaving, setIsSaving] = useState(false);
   const [notification, setNotification] = useState("");
+  const [notificationIsError, setNotificationIsError] = useState(false);
 
-  const loadDialogData = async () => {
+  const loadDialogData = useCallback(async () => {
     if (!post?.id) return;
 
     setLoading(true);
     setNotification("");
+    setNotificationIsError(false);
 
     try {
       const [fetchedPostTags, fetchedAllTags] = await Promise.all([
@@ -44,17 +46,17 @@ export const EditPostTagsDialog = ({
       console.error("Failed to load tag editor data:", error);
       setPostTags([]);
       setAllTags([]);
+      setNotificationIsError(true);
       setNotification("Failed to load tags.");
     } finally {
       setLoading(false);
     }
-  };
+  }, [post?.id]);
 
   // Load data when dialog mounts / post changes
   useEffect(() => {
-    if (!post?.id) return;
     loadDialogData();
-  }, [post?.id]);
+  }, [loadDialogData]);
 
   // Show dialog after mount
   useEffect(() => {
@@ -76,6 +78,7 @@ export const EditPostTagsDialog = ({
 
     setIsSaving(true);
     setNotification("");
+    setNotificationIsError(false);
 
     try {
       await removeTagFromPost(postTagId);
@@ -86,6 +89,7 @@ export const EditPostTagsDialog = ({
       setNotification("Tag removed.");
     } catch (error) {
       console.error("Failed to remove tag from post:", error);
+      setNotificationIsError(true);
       setNotification("Failed to remove tag.");
     } finally {
       setIsSaving(false);
@@ -97,6 +101,7 @@ export const EditPostTagsDialog = ({
 
     setIsSaving(true);
     setNotification("");
+    setNotificationIsError(false);
 
     try {
       const tagId = parseInt(selectedTagId);
@@ -110,6 +115,7 @@ export const EditPostTagsDialog = ({
       setNotification("Tag added.");
     } catch (error) {
       console.error("Failed to add tag to post:", error);
+      setNotificationIsError(true);
       setNotification("Failed to add tag.");
     } finally {
       setIsSaving(false);
@@ -127,12 +133,14 @@ export const EditPostTagsDialog = ({
     );
 
     if (tagAlreadyExists) {
+      setNotificationIsError(true);
       setNotification("That tag already exists.");
       return;
     }
 
     setIsSaving(true);
     setNotification("");
+    setNotificationIsError(false);
 
     try {
       const createdTag = await createTag({ label: trimmedLabel });
@@ -148,6 +156,7 @@ export const EditPostTagsDialog = ({
       setNotification("New tag created and added.");
     } catch (error) {
       console.error("Failed to create and add tag:", error);
+      setNotificationIsError(true);
       setNotification("Failed to create and add tag.");
     } finally {
       setIsSaving(false);
@@ -286,7 +295,11 @@ export const EditPostTagsDialog = ({
                 </div>
               ) : null}
 
-              {notification ? <p className="help mt-2">{notification}</p> : null}
+              {notification ? (
+                <p className={`help mt-2 ${notificationIsError ? "has-text-danger" : "has-text-success"}`}>
+                  {notification}
+                </p>
+              ) : null}
             </>
           )}
         </div>

--- a/src/components/posts/EditPostTagsDialog.jsx
+++ b/src/components/posts/EditPostTagsDialog.jsx
@@ -26,35 +26,37 @@ export const EditPostTagsDialog = ({
   const [isSaving, setIsSaving] = useState(false);
   const [notification, setNotification] = useState("");
 
-  // Open dialog + fetch needed data
-  useEffect(() => {
+  const loadDialogData = async () => {
     if (!post?.id) return;
 
-    const loadDialogData = async () => {
-      setLoading(true);
+    setLoading(true);
+    setNotification("");
 
-      try {
-        const [fetchedPostTags, fetchedAllTags] = await Promise.all([
-          getTagsByPostId(post.id),
-          getAllTags(),
-        ]);
+    try {
+      const [fetchedPostTags, fetchedAllTags] = await Promise.all([
+        getTagsByPostId(post.id),
+        getAllTags(),
+      ]);
 
-        setPostTags(fetchedPostTags ?? []);
-        setAllTags(fetchedAllTags ?? []);
-      } catch (error) {
-        console.error("Failed to load tag editor data:", error);
-        setPostTags([]);
-        setAllTags([]);
-        setNotification("Failed to load tags.");
-      } finally {
-        setLoading(false);
-      }
-    };
+      setPostTags(fetchedPostTags ?? []);
+      setAllTags(fetchedAllTags ?? []);
+    } catch (error) {
+      console.error("Failed to load tag editor data:", error);
+      setPostTags([]);
+      setAllTags([]);
+      setNotification("Failed to load tags.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
+  // Load data when dialog mounts / post changes
+  useEffect(() => {
+    if (!post?.id) return;
     loadDialogData();
   }, [post?.id]);
 
-  // Show the dialog after mount
+  // Show dialog after mount
   useEffect(() => {
     dialogRef.current?.showModal();
   }, []);
@@ -64,21 +66,23 @@ export const EditPostTagsDialog = ({
     return new Set(postTags.map((tag) => tag.id));
   }, [postTags]);
 
-  // Only show tags that are not already attached
+  // Only show tags not already attached
   const availableTagsToAdd = useMemo(() => {
     return allTags.filter((tag) => !attachedTagIds.has(tag.id));
   }, [allTags, attachedTagIds]);
 
-  const handleRemoveTag = async (tagId) => {
+  const handleRemoveTag = async (postTagId) => {
     if (!canRemoveTags) return;
 
     setIsSaving(true);
     setNotification("");
 
     try {
-      await removeTagFromPost(post.id, tagId);
+      await removeTagFromPost(postTagId);
 
-      setPostTags((current) => current.filter((tag) => tag.id !== tagId));
+      const refreshedPostTags = await getTagsByPostId(post.id);
+      setPostTags(refreshedPostTags ?? []);
+
       setNotification("Tag removed.");
     } catch (error) {
       console.error("Failed to remove tag from post:", error);
@@ -99,10 +103,8 @@ export const EditPostTagsDialog = ({
 
       await addTagToPost(post.id, tagId);
 
-      const addedTag = allTags.find((tag) => tag.id === tagId);
-      if (addedTag) {
-        setPostTags((current) => [...current, addedTag]);
-      }
+      const refreshedPostTags = await getTagsByPostId(post.id);
+      setPostTags(refreshedPostTags ?? []);
 
       setSelectedTagId("");
       setNotification("Tag added.");
@@ -117,21 +119,31 @@ export const EditPostTagsDialog = ({
   const handleCreateAndAddTag = async () => {
     if (!canCreateTags || !newTagLabel.trim()) return;
 
+    const trimmedLabel = newTagLabel.trim();
+    const normalizedNewTag = trimmedLabel.toLowerCase();
+
+    const tagAlreadyExists = allTags.some(
+      (tag) => tag.label.trim().toLowerCase() === normalizedNewTag
+    );
+
+    if (tagAlreadyExists) {
+      setNotification("That tag already exists.");
+      return;
+    }
+
     setIsSaving(true);
     setNotification("");
 
     try {
-      // Create the new tag first
-      const createdTag = await createTag({ label: newTagLabel.trim() });
+      const createdTag = await createTag({ label: trimmedLabel });
 
-      // Depending on your service, createdTag may already be the tag object
-      // with id + label. If not, you may need to re-fetch all tags here.
-      const usableTag = createdTag;
+      await addTagToPost(post.id, createdTag.id);
 
-      await addTagToPost(post.id, usableTag.id);
+      setAllTags((current) => [...current, createdTag]);
 
-      setAllTags((current) => [...current, usableTag]);
-      setPostTags((current) => [...current, usableTag]);
+      const refreshedPostTags = await getTagsByPostId(post.id);
+      setPostTags(refreshedPostTags ?? []);
+
       setNewTagLabel("");
       setNotification("New tag created and added.");
     } catch (error) {
@@ -162,15 +174,17 @@ export const EditPostTagsDialog = ({
             <Loading />
           ) : (
             <>
-              {/* Existing tags */}
               <div className="mb-4">
                 <p className="has-text-weight-semibold mb-2">Current Tags</p>
 
                 {postTags.length ? (
-                  <div className="is-flex is-flex-direction-column" style={{ gap: "0.75rem" }}>
+                  <div
+                    className="is-flex is-flex-direction-column"
+                    style={{ gap: "0.75rem" }}
+                  >
                     {postTags.map((tag) => (
                       <div
-                        key={tag.id}
+                        key={tag.postTagId}
                         className="is-flex is-justify-content-space-between is-align-items-center"
                         style={{ gap: "0.75rem" }}
                       >
@@ -183,7 +197,7 @@ export const EditPostTagsDialog = ({
                             color="danger"
                             light
                             disabled={isSaving}
-                            onClick={() => handleRemoveTag(tag.id)}
+                            onClick={() => handleRemoveTag(tag.postTagId)}
                           >
                             Remove
                           </Button>
@@ -192,46 +206,47 @@ export const EditPostTagsDialog = ({
                     ))}
                   </div>
                 ) : (
-                  <p className="is-size-7 has-text-grey">This post has no tags.</p>
+                  <p className="is-size-7 has-text-grey">
+                    This post has no tags.
+                  </p>
                 )}
               </div>
 
-              {/* Add existing tag */}
               {canAddTags ? (
                 <div className="mb-4">
-                  <p className="has-text-weight-semibold mb-2">Add Existing Tag</p>
+                  <p className="has-text-weight-semibold mb-2">
+                    Add Existing Tag
+                  </p>
 
                   {availableTagsToAdd.length ? (
-                    <>
-                      <div className="field has-addons">
-                        <div className="control is-expanded">
-                          <div className="select is-fullwidth">
-                            <select
-                              value={selectedTagId}
-                              onChange={(e) => setSelectedTagId(e.target.value)}
-                              disabled={isSaving}
-                            >
-                              <option value="">Select a tag</option>
-                              {availableTagsToAdd.map((tag) => (
-                                <option key={tag.id} value={tag.id}>
-                                  {tag.label}
-                                </option>
-                              ))}
-                            </select>
-                          </div>
-                        </div>
-
-                        <div className="control">
-                          <Button
-                            color="primary"
-                            disabled={isSaving || !selectedTagId}
-                            onClick={handleAddExistingTag}
+                    <div className="field has-addons">
+                      <div className="control is-expanded">
+                        <div className="select is-fullwidth">
+                          <select
+                            value={selectedTagId}
+                            onChange={(e) => setSelectedTagId(e.target.value)}
+                            disabled={isSaving}
                           >
-                            Add
-                          </Button>
+                            <option value="">Select a tag</option>
+                            {availableTagsToAdd.map((tag) => (
+                              <option key={tag.id} value={tag.id}>
+                                {tag.label}
+                              </option>
+                            ))}
+                          </select>
                         </div>
                       </div>
-                    </>
+
+                      <div className="control">
+                        <Button
+                          color="primary"
+                          disabled={isSaving || !selectedTagId}
+                          onClick={handleAddExistingTag}
+                        >
+                          Add
+                        </Button>
+                      </div>
+                    </div>
                   ) : (
                     <p className="is-size-7 has-text-grey">
                       No additional existing tags are available to add.
@@ -240,10 +255,11 @@ export const EditPostTagsDialog = ({
                 </div>
               ) : null}
 
-              {/* Create and add new tag */}
               {canCreateTags ? (
                 <div className="mb-3">
-                  <p className="has-text-weight-semibold mb-2">Create New Tag</p>
+                  <p className="has-text-weight-semibold mb-2">
+                    Create New Tag
+                  </p>
 
                   <div className="field has-addons">
                     <div className="control is-expanded">
@@ -270,9 +286,7 @@ export const EditPostTagsDialog = ({
                 </div>
               ) : null}
 
-              {notification ? (
-                <p className="help mt-2">{notification}</p>
-              ) : null}
+              {notification ? <p className="help mt-2">{notification}</p> : null}
             </>
           )}
         </div>

--- a/src/components/posts/EditPostTagsDialog.jsx
+++ b/src/components/posts/EditPostTagsDialog.jsx
@@ -27,6 +27,9 @@ export const EditPostTagsDialog = ({
   const [notification, setNotification] = useState("");
   const [notificationIsError, setNotificationIsError] = useState(false);
 
+  // Load both the tags currently attached to this post and all available tags in the system.
+  // This allows us to show current tags with remove buttons and also provide a dropdown of available tags to add.
+  // We use useCallback to memoize this function so that it doesn't get re-created on every render, which would cause the useEffect that depends on it to run more often than necessary.
   const loadDialogData = useCallback(async () => {
     if (!post?.id) return;
 
@@ -73,6 +76,7 @@ export const EditPostTagsDialog = ({
     return allTags.filter((tag) => !attachedTagIds.has(tag.id));
   }, [allTags, attachedTagIds]);
 
+  // Handlers for adding/removing tags, creating new tags, and closing the dialog.
   const handleRemoveTag = async (postTagId) => {
     if (!canRemoveTags) return;
 
@@ -96,6 +100,7 @@ export const EditPostTagsDialog = ({
     }
   };
 
+  // Handler for adding an existing tag to the post. This is only allowed if the user has permission to add tags and has selected a tag from the dropdown.
   const handleAddExistingTag = async () => {
     if (!canAddTags || !selectedTagId) return;
 
@@ -122,6 +127,8 @@ export const EditPostTagsDialog = ({
     }
   };
 
+  // Handler for creating a new tag and adding it to the post. 
+  // Only admins can create new tags.
   const handleCreateAndAddTag = async () => {
     if (!canCreateTags || !newTagLabel.trim()) return;
 
@@ -186,6 +193,7 @@ export const EditPostTagsDialog = ({
               <div className="mb-4">
                 <p className="has-text-weight-semibold mb-2">Current Tags</p>
 
+                {/* Show the tags currently attached to this post, with a "Remove" button if the user has permission to remove tags. */}
                 {postTags.length ? (
                   <div
                     className="is-flex is-flex-direction-column"
@@ -221,6 +229,7 @@ export const EditPostTagsDialog = ({
                 )}
               </div>
 
+                {/* If the user has permission to add tags, show the UI for adding an existing tag. This includes a dropdown of available tags that are not already attached to the post and an "Add" button. */}
               {canAddTags ? (
                 <div className="mb-4">
                   <p className="has-text-weight-semibold mb-2">
@@ -264,6 +273,7 @@ export const EditPostTagsDialog = ({
                 </div>
               ) : null}
 
+              {/* Only admins can create new tags on the fly. */}
               {canCreateTags ? (
                 <div className="mb-3">
                   <p className="has-text-weight-semibold mb-2">

--- a/src/components/posts/NewPost.jsx
+++ b/src/components/posts/NewPost.jsx
@@ -1,13 +1,19 @@
-import { useState, useEffect } from "react"
-import { useNavigate } from "react-router-dom"
-import { createPost, getAllCategories, getAllTags } from "../../services"
-import { Container, PageHeader } from "../../design"
-import { useCurrentUser } from "../../context/CurrentUserContext.js"
-import { PostForm } from "./PostForm"
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  createPost,
+  getAllCategories,
+  getAllTags,
+  addTagToPost,
+} from "../../services";
+import { Container, PageHeader } from "../../design";
+import { useCurrentUser } from "../../context/CurrentUserContext.js";
+import { PostForm } from "./PostForm";
 
 export const NewPost = () => {
-  const { currentUser } = useCurrentUser()
-  const navigate = useNavigate()
+  const { currentUser } = useCurrentUser();
+  const [selectedTagIds, setSelectedTagIds] = useState([]);
+  const navigate = useNavigate();
 
   const [post, setPost] = useState({
     user_id: currentUser?.id || 0,
@@ -15,70 +21,86 @@ export const NewPost = () => {
     image_url: "",
     content: "",
     category_id: "",
-    tag_ids: [],
-  })
+  });
 
-  const [categories, setCategories] = useState([])
-  const [tags, setTags] = useState([])
-  const [submitError, setSubmitError] = useState("")
+  const [categories, setCategories] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [submitError, setSubmitError] = useState("");
 
   useEffect(() => {
-    getAllCategories().then(setCategories)
-    getAllTags().then(setTags)
-  }, [])
+    Promise.all([getAllCategories(), getAllTags()])
+      .then(([fetchedCategories, fetchedTags]) => {
+        setCategories(fetchedCategories);
+        setTags(fetchedTags);
+      })
+      .catch((error) => {
+        console.error("Failed to fetch categories or tags:", error);
+      });
+  }, []);
 
   useEffect(() => {
     if (currentUser?.id) {
       setPost((prev) => ({
         ...prev,
         user_id: currentUser.id,
-      }))
+      }));
     }
-  }, [currentUser])
+  }, [currentUser]);
 
   const handleInputChange = (e) => {
-    const { name, value } = e.target
+    const { name, value } = e.target;
     setPost((prev) => ({
       ...prev,
       [name]: value,
-    }))
-  }
+    }));
+  };
 
   const handleCategoryChange = (e) => {
     setPost((prev) => ({
       ...prev,
       category_id: parseInt(e.target.value),
-    }))
-  }
+    }));
+  };
 
   const handleTagChange = (e) => {
-    const tagId = parseInt(e.target.value)
-    setPost((prev) => ({
-      ...prev,
-      tag_ids: e.target.checked
-        ? [...prev.tag_ids, tagId]
-        : prev.tag_ids.filter((id) => id !== tagId),
-    }))
-  }
+    const tagId = parseInt(e.target.value);
 
-  const handleSubmit = (e) => {
-    e.preventDefault()
-    setSubmitError("")
+    setSelectedTagIds((prev) =>
+      e.target.checked ? [...prev, tagId] : prev.filter((id) => id !== tagId),
+    );
+  };
 
-    const postData = {
-      ...post,
-      category_id: parseInt(post.category_id),
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError("");
+
+    try {
+      const postData = {
+        user_id: post.user_id,
+        title: post.title,
+        image_url: post.image_url,
+        content: post.content,
+        category_id: parseInt(post.category_id),
+      };
+
+      const createdPost = await createPost(postData);
+
+      if (selectedTagIds.length) {
+        try {
+          await Promise.all(
+            selectedTagIds.map((tagId) => addTagToPost(createdPost.id, tagId)),
+          );
+        } catch (tagError) {
+          console.error("Post created but failed to attach some tags:", tagError);
+        }
+      }
+
+      navigate("/my-posts");
+    } catch (error) {
+      console.error("Failed to create post:", error);
+      setSubmitError("Something went wrong while creating your post.");
     }
-
-    createPost(postData)
-      .then(() => {
-        navigate("/my-posts")
-      })
-      .catch((error) => {
-        console.error("Failed to create post:", error)
-        setSubmitError("Something went wrong while creating your post.")
-      })
-  }
+  };
 
   return (
     <Container>
@@ -96,6 +118,7 @@ export const NewPost = () => {
             onInputChange={handleInputChange}
             onCategoryChange={handleCategoryChange}
             onTagChange={handleTagChange}
+            selectedTagIds={selectedTagIds}
             onSubmit={handleSubmit}
             onCancel={() => navigate("/my-posts")}
             submitError={submitError}
@@ -107,5 +130,5 @@ export const NewPost = () => {
         </div>
       </div>
     </Container>
-  )
-}
+  );
+};

--- a/src/components/posts/PostDetails.jsx
+++ b/src/components/posts/PostDetails.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 // useParams lets us read the :postId from the URL (e.g. /posts/5 → postId = "5")
 import { useParams, useNavigate, Link } from "react-router-dom";
 // Custom service function we created in PostService.js to fetch a single post by ID
@@ -17,7 +17,6 @@ import {
 import { DeletePostButton } from "../../design/DeletePostButton";
 import { ReactionBar } from "../reactions/ReactionBar.jsx";
 
-// New component for Ticket #5 - View Post Details
 // Displays a single post's full details when a user clicks a post title from a list
 export const PostDetails = () => {
   // Extracts the postId from the URL parameter defined in ApplicationViews route
@@ -25,6 +24,8 @@ export const PostDetails = () => {
   const navigate = useNavigate();
   // Holds the fetched post data; starts as null to trigger "Loading..." state
   const [post, setPost] = useState(null);
+  const [tagNotification, setTagNotification] = useState("");
+  const updateTagsDialogRef = useRef();
 
   // Fetches the single post from the API when component mounts or postId changes
   useEffect(() => {

--- a/src/components/posts/PostDetails.jsx
+++ b/src/components/posts/PostDetails.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useCallback } from "react";
 // useParams lets us read the :postId from the URL (e.g. /posts/5 → postId = "5")
 import { useParams, useNavigate, Link } from "react-router-dom";
 // Custom service function we created in PostService.js to fetch a single post by ID
@@ -16,6 +16,7 @@ import {
 
 import { DeletePostButton } from "../../design/DeletePostButton";
 import { ReactionBar } from "../reactions/ReactionBar.jsx";
+import { PostTagAside } from "./PostTagAside.jsx";
 
 // Displays a single post's full details when a user clicks a post title from a list
 export const PostDetails = () => {
@@ -24,13 +25,15 @@ export const PostDetails = () => {
   const navigate = useNavigate();
   // Holds the fetched post data; starts as null to trigger "Loading..." state
   const [post, setPost] = useState(null);
-  const [tagNotification, setTagNotification] = useState("");
-  const updateTagsDialogRef = useRef();
+
+  const fetchPost = useCallback(() => {
+    getPostByIdExpandCategoryExpandUser(postId).then(setPost);
+  }, [postId]);
 
   // Fetches the single post from the API when component mounts or postId changes
   useEffect(() => {
-    getPostByIdExpandCategoryExpandUser(postId).then(setPost);
-  }, [postId]);
+    fetchPost();
+  }, [postId, fetchPost]);
 
   // Show loading message while waiting for API response (post is still null)
   if (!post) return <Loading />;
@@ -46,7 +49,7 @@ export const PostDetails = () => {
         <h1 className="title is-2 has-text-centered mb-4">{post.title}</h1>
 
         {/* Row above the image:
-            - Left: edit/delete icons (dead links for now)
+            - Left: edit/delete icons
             - Right: category label
         */}
         <div className="level mb-3">
@@ -76,15 +79,23 @@ export const PostDetails = () => {
         </div>
 
         {/* Only render the header image if the post has an image_url */}
-        {post.image_url ? (
-          <figure className="image mb-4">
-            <img
-              src={post.image_url}
-              alt="Post header"
-              style={{ width: "100%", borderRadius: "8px" }}
-            />
-          </figure>
-        ) : null}
+        <div className="columns is-variable is-5">
+          <div className="column is-three-quarters">
+            {post.image_url ? (
+              <figure className="image mb-4">
+                <img
+                  src={post.image_url}
+                  alt="Post header"
+                  style={{ width: "100%", borderRadius: "8px" }}
+                />
+              </figure>
+            ) : null}
+          </div>
+
+          <div className="column is-one-quarter">
+            <PostTagAside post={post} onTagsUpdated={fetchPost} />
+          </div>
+        </div>
 
         {/* Row under the image:
             - Left: author name

--- a/src/components/posts/PostDetails.jsx
+++ b/src/components/posts/PostDetails.jsx
@@ -55,17 +55,20 @@ export const PostDetails = () => {
         <div className="level mb-3">
           <div className="level-left">
             <div className="buttons are-small">
-              {/* "Edit post" (dead for now) */}
+              {/* "Edit post" */}
               <IconButton
                 icon="gear"
-                title="Edit post (coming soon)"
-                onClick={() => {}}
+                title="Edit post"
+                onClick={() => navigate(`/my-posts/edit/${post.id}`)}
               />
-              {/* "Delete post" (dead for now) */}
-              <IconButton
+              {/* "Delete post" */}
+              <DeletePostButton
                 icon="trash"
-                title="Delete post (coming soon)"
-                onClick={() => {}}
+                userId={post.user_id}
+                postId={post.id}
+                title="Delete post"
+                confirmTitle="Delete Post"
+                confirmMessage="Are you sure you want to delete this post? This action cannot be undone."
               />
             </div>
           </div>
@@ -121,13 +124,6 @@ export const PostDetails = () => {
               >
                 View Comments
               </Button>
-              <DeletePostButton
-                userId={post.user_id}
-                postId={post.id}
-                title="Delete Post"
-                confirmTitle="Delete Post"
-                confirmMessage="Are you sure you want to delete this post? This action cannot be undone."
-              />
             </div>
           </div>
 

--- a/src/components/posts/PostDetails.jsx
+++ b/src/components/posts/PostDetails.jsx
@@ -26,6 +26,8 @@ export const PostDetails = () => {
   // Holds the fetched post data; starts as null to trigger "Loading..." state
   const [post, setPost] = useState(null);
 
+  // Use useCallback to memoize the fetchPost function, so it only changes if postId changes instead of on every render. 
+  // This prevents unnecessary re-fetching and avoids infinite loops in useEffect.
   const fetchPost = useCallback(() => {
     getPostByIdExpandCategoryExpandUser(postId).then(setPost);
   }, [postId]);

--- a/src/components/posts/PostForm.jsx
+++ b/src/components/posts/PostForm.jsx
@@ -1,4 +1,5 @@
-// Reusable form component for creating and editing posts, with support for categories, tags, and image URLs.
+// Reusable form component for creating and editing posts
+// with support for categories, optional image URLs, and optional tag selection.
 import {
   Form,
   FormField,
@@ -6,7 +7,7 @@ import {
   FormSelect,
   Button,
   Card,
-} from "../../design"
+} from "../../design";
 
 export const PostForm = ({
   post,
@@ -21,7 +22,8 @@ export const PostForm = ({
   showImageUrl = false,
   showTags = false,
   tags = [],
-  onTagChange,
+  selectedTagIds = [],
+  onTagChange = () => {},
 }) => {
   return (
     <Card className="edit-form-card">
@@ -87,7 +89,7 @@ export const PostForm = ({
                   <input
                     type="checkbox"
                     value={tag.id}
-                    checked={post.tag_ids?.includes(tag.id)}
+                    checked={selectedTagIds?.includes(tag.id)}
                     onChange={onTagChange}
                   />{" "}
                   {tag.label}
@@ -97,9 +99,11 @@ export const PostForm = ({
           </div>
         ) : null}
 
-        {submitError ? <p className="has-text-danger mb-4">{submitError}</p> : null}
+        {submitError ? (
+          <p className="has-text-danger mb-4">{submitError}</p>
+        ) : null}
 
-        <div className="is-flex is-justify-content-flex-end is-gap-3">
+        <div className="is-flex is-justify-content-flex-end" style={{ gap: "0.75rem" }}>
           <Button type="button" className="is-light" onClick={onCancel}>
             {cancelLabel}
           </Button>
@@ -110,5 +114,5 @@ export const PostForm = ({
         </div>
       </Form>
     </Card>
-  )
-}
+  );
+};

--- a/src/components/posts/PostTagAside.jsx
+++ b/src/components/posts/PostTagAside.jsx
@@ -9,8 +9,10 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
   const [isEditingTags, setIsEditingTags] = useState(false);
   const [tags, setTags] = useState([]);
 
+  // Grab the postId from the post prop for easier use in API calls
   const postId = post?.id;
 
+  // Use useCallback to memoize the fetchTags function, so it only changes if postId changes instead of on every render.
   const fetchTags = useCallback(() => {
     if (!postId) return;
 
@@ -28,6 +30,7 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
     fetchTags();
   }, [fetchTags]);
 
+  // Determine permissions based on current user and post ownership
   const isOwner = currentUser?.id === post?.user_id;
   const isAdmin = currentUser?.is_staff === true;
 
@@ -35,10 +38,12 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
   // Admins can edit tags on any post.
   const canEditTags = isOwner || isAdmin;
 
+  // Authors may add existing tags to their own posts.
   // Admins may add existing tags to any post.
-  const canAddTags = isAdmin;
+  const canAddTags = isOwner || isAdmin;
 
-  // Admins may create a new tag and add it to any post.
+  // Admins may create a new tag and add it to any post on the fly. 
+  // Authors cannot create new tags.
   const canCreateTags = isAdmin;
 
   return (
@@ -61,6 +66,8 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
           <p className="is-size-7 has-text-grey mb-3">No tags assigned.</p>
         )}
 
+        {/* Only show the "Manage Tags" button if the user has permission to edit tags 
+        which is just authors of the post or admins */}
         {canEditTags ? (
           <div className="mt-4">
             <Button color="primary" onClick={() => setIsEditingTags(true)}>
@@ -70,6 +77,8 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
         ) : null}
       </aside>
 
+      {/* Render the EditPostTagsDialog modal while isEditingTags is true.
+      We pass down the post, permissions, and callbacks to handle closing and updating tags. */}
       {isEditingTags ? (
         <EditPostTagsDialog
           post={post}

--- a/src/components/posts/PostTagAside.jsx
+++ b/src/components/posts/PostTagAside.jsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { Button, Tag } from "../../design";
+import { useCurrentUser } from "../../context/CurrentUserContext";
+import { EditPostTagsDialog } from "./EditPostTagsDialog";
+
+export const PostTagAside = ({ post, onTagsUpdated }) => {
+  const { currentUser } = useCurrentUser();
+  const [isEditingTags, setIsEditingTags] = useState(false);
+
+  const tags = post?.tags ?? [];
+
+  const isOwner = currentUser?.id === post?.user_id;
+  const isAdmin = currentUser?.is_staff === true;
+
+  // Authors can edit tags on their own posts (remove only).
+  // Admins can edit tags on any post.
+  const canEditTags = isOwner || isAdmin;
+
+  // Authors may only remove tags.
+  const canRemoveTags = isOwner || isAdmin;
+
+  // Admins may add existing tags to any post.
+  const canAddTags = isAdmin;
+
+  // Admins may create a new tag and add it to any post.
+  const canCreateTags = isAdmin;
+
+  return (
+    <>
+      <aside className="box">
+        <p className="has-text-weight-semibold mb-3">Tags</p>
+
+        {tags.length ? (
+          <div
+            className="is-flex is-flex-direction-column"
+            style={{ gap: "0.5rem" }}
+          >
+            {tags.map((tag) => (
+              <Tag key={tag.id} color="warning" light rounded>
+                {tag.label}
+              </Tag>
+            ))}
+          </div>
+        ) : (
+          <p className="is-size-7 has-text-grey mb-3">No tags assigned.</p>
+        )}
+
+        {canEditTags ? (
+          <div className="mt-4">
+            <Button color="primary" onClick={() => setIsEditingTags(true)}>
+              Edit Tags
+            </Button>
+          </div>
+        ) : null}
+      </aside>
+
+      {isEditingTags ? (
+        <EditPostTagsDialog
+          post={post}
+          canAddTags={canAddTags}
+          canCreateTags={canCreateTags}
+          canRemoveTags={canRemoveTags}
+          onClose={() => setIsEditingTags(false)}
+          onUpdated={() => {
+            setIsEditingTags(false);
+            onTagsUpdated?.();
+          }}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/src/components/posts/PostTagAside.jsx
+++ b/src/components/posts/PostTagAside.jsx
@@ -35,9 +35,6 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
   // Admins can edit tags on any post.
   const canEditTags = isOwner || isAdmin;
 
-  // Authors may only remove tags.
-  const canRemoveTags = isOwner || isAdmin;
-
   // Admins may add existing tags to any post.
   const canAddTags = isAdmin;
 
@@ -47,7 +44,7 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
   return (
     <>
       <aside className="box">
-        <p className="has-text-weight-semibold mb-3">Tags</p>
+        <p className="has-text-weight-semibold mb-3 has-text-centered">Tags Associated with this Post</p>
 
         {tags.length ? (
           <div
@@ -67,7 +64,7 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
         {canEditTags ? (
           <div className="mt-4">
             <Button color="primary" onClick={() => setIsEditingTags(true)}>
-              Edit Tags
+              Manage Tags for this Post
             </Button>
           </div>
         ) : null}
@@ -78,7 +75,7 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
           post={post}
           canAddTags={canAddTags}
           canCreateTags={canCreateTags}
-          canRemoveTags={canRemoveTags}
+          canRemoveTags={canEditTags}
           onClose={() => setIsEditingTags(false)}
           onUpdated={() => {
             setIsEditingTags(false);

--- a/src/components/posts/PostTagAside.jsx
+++ b/src/components/posts/PostTagAside.jsx
@@ -1,13 +1,32 @@
-import { useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Button, Tag } from "../../design";
 import { useCurrentUser } from "../../context/CurrentUserContext";
 import { EditPostTagsDialog } from "./EditPostTagsDialog";
+import { getTagsByPostId } from "../../services";
 
 export const PostTagAside = ({ post, onTagsUpdated }) => {
   const { currentUser } = useCurrentUser();
   const [isEditingTags, setIsEditingTags] = useState(false);
+  const [tags, setTags] = useState([]);
 
-  const tags = post?.tags ?? [];
+  const postId = post?.id;
+
+  const fetchTags = useCallback(() => {
+    if (!postId) return;
+
+    getTagsByPostId(postId)
+      .then((fetchedTags) => {
+        setTags(fetchedTags ?? []);
+      })
+      .catch((error) => {
+        console.error("Failed to fetch tags for post:", error);
+        setTags([]);
+      });
+  }, [postId]);
+
+  useEffect(() => {
+    fetchTags();
+  }, [fetchTags]);
 
   const isOwner = currentUser?.id === post?.user_id;
   const isAdmin = currentUser?.is_staff === true;
@@ -63,6 +82,7 @@ export const PostTagAside = ({ post, onTagsUpdated }) => {
           onClose={() => setIsEditingTags(false)}
           onUpdated={() => {
             setIsEditingTags(false);
+            fetchTags();
             onTagsUpdated?.();
           }}
         />

--- a/src/design/ConfirmDialog.js
+++ b/src/design/ConfirmDialog.js
@@ -42,7 +42,7 @@ export const ConfirmDialog = ({
 
         <div className="modal-card">
           <header className="modal-card-head">
-            <p className="modal-card-title">{title}</p>
+            <p className="modal-card-title" style={{ minWidth: 0, flexShrink: 1, wordBreak: "break-word" }}>{title}</p>
             <button
               type="button"
               className="delete"
@@ -52,7 +52,7 @@ export const ConfirmDialog = ({
           </header>
 
           <section className="modal-card-body">
-            <p>{message}</p>
+            <div>{message}</div>
           </section>
 
           <footer className="modal-card-foot">

--- a/src/design/DeletePostButton.jsx
+++ b/src/design/DeletePostButton.jsx
@@ -24,7 +24,7 @@ export const DeletePostButton = ({
   const dialogRef = useRef(null)
 
   if (isLoading || !currentUser) return null
-  if (currentUser.id !== userId) return null
+  if (currentUser.id !== userId && !currentUser.is_staff) return null
 
   const openDialog = () => {
     // <dialog> must be opened via showModal()

--- a/src/services/PostTagsService.js
+++ b/src/services/PostTagsService.js
@@ -1,0 +1,26 @@
+import { fetchJson, postJson, deleteJson } from "./apiSettings";
+
+export const getTagsByPostId = async (postId) => {
+    const rows = await fetchJson(`/posttags?post_id=${postId}&_expand=tag`);
+
+    return rows.map((row) => ({
+        postTagId: row.id,
+        id: row.tag.id,
+        label: row.tag.label
+    }));
+};
+
+export const addTagToPost = async (postId, tagId) => {
+    try {
+        return await postJson("/posttags", {
+            post_id: postId,
+            tag_id: tagId
+        });
+    } catch (err) {
+        console.warn("Tag already assigned to this post.");
+    }
+};
+
+export const removeTagFromPost = (postTagId) => {
+    return deleteJson(`/posttags/${postTagId}`);
+};

--- a/src/services/PostTagsService.js
+++ b/src/services/PostTagsService.js
@@ -6,7 +6,8 @@ export const getTagsByPostId = async (postId) => {
     return rows.map((row) => ({
         postTagId: row.id,
         id: row.tag.id,
-        label: row.tag.label
+        label: row.tag.label,
+        created_on: row.created_on,
     }));
 };
 
@@ -14,10 +15,11 @@ export const addTagToPost = async (postId, tagId) => {
     try {
         return await postJson("/posttags", {
             post_id: postId,
-            tag_id: tagId
+            tag_id: tagId,
         });
     } catch (err) {
-        console.warn("Tag already assigned to this post.");
+        console.warn(err?.message || "Failed to add tag to post.");
+        throw err;
     }
 };
 

--- a/src/services/TagService.js
+++ b/src/services/TagService.js
@@ -1,4 +1,4 @@
-import { fetchJson, postJson, deleteJson } from "./apiSettings";
+import { fetchJson, postJson, putJson, deleteJson } from "./apiSettings";
 
 // Function to get all tags from the API Ticket #10
 export const getAllTags = () => {
@@ -18,8 +18,17 @@ export const getTagById = (id) => {
 };
 
 export const editTag = (id, updatedTag) => {
-  return fetchJson(`/tags/${id}`, {
-    method: "PUT",
-    body: JSON.stringify(updatedTag),
-  });
+  return putJson(`/tags/${id}`, updatedTag);
+};
+
+export const getTagsByPostId = (postId) => {
+  return fetchJson(`/posts/${postId}/tags`);
+};
+
+export const addTagToPost = (postId, tagId) => {
+  return postJson(`/posts/${postId}/tags`, { tag_id: tagId });
+};
+
+export const removeTagFromPost = (postId, tagId) => {
+  return deleteJson(`/posts/${postId}/tags/${tagId}`);
 };

--- a/src/services/TagService.js
+++ b/src/services/TagService.js
@@ -1,6 +1,5 @@
 import { fetchJson, postJson, putJson, deleteJson } from "./apiSettings";
 
-// Function to get all tags from the API Ticket #10
 export const getAllTags = () => {
   return fetchJson("/tags");
 };
@@ -8,7 +7,7 @@ export const getAllTags = () => {
 export const createTag = (tag) => {
   return postJson("/tags", tag);
 };
-// Ticket #18 function that deletes Tags from the API
+
 export const deleteTag = (id) => {
   return deleteJson(`/tags/${id}`);
 };
@@ -19,16 +18,4 @@ export const getTagById = (id) => {
 
 export const editTag = (id, updatedTag) => {
   return putJson(`/tags/${id}`, updatedTag);
-};
-
-export const getTagsByPostId = (postId) => {
-  return fetchJson(`/posts/${postId}/tags`);
-};
-
-export const addTagToPost = (postId, tagId) => {
-  return postJson(`/posts/${postId}/tags`, { tag_id: tagId });
-};
-
-export const removeTagFromPost = (postId, tagId) => {
-  return deleteJson(`/posts/${postId}/tags/${tagId}`);
 };

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -70,3 +70,10 @@ export {
   updateDemotionQueueEntry,
   deleteDemotionQueueEntry,
 } from "./DemotionQueue.js";
+
+// PostTags 
+export {
+  getTagsByPostId,
+  addTagToPost,
+  removeTagFromPost,
+} from "./PostTagsService.js";


### PR DESCRIPTION
# Description

Adds client-side support for managing tags on posts (Tickets #20 and #10 ), including selecting tags when creating a post and managing post tags from the post details page.

This update also introduces a dedicated tag management dialog, a `<PostTags>` sidebar, and supporting client services for attaching and removing tags from posts.

## Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update

## Testing

- [x] Navigate to **New Post** and verify available tags are shown in the post form
- [x] Select one or more tags while creating a post then confirm the post is created successfully and redirects to **My Posts**
- [x] Open the created post’s **Post Details** page and verify the assigned tags appear in the tag sidebar
- [x] Click **Manage Tags for this Post** and then add an existing tag that is not already attached to the post confirming the tag appears in the dialog and in the sidebar
- [x] Remove an existing tag from the post confirming the tag is removed from the dialog and sidebar
- [x] Log in as an admin and open **Manage Tags for this Post**. Then create a new tag on the fly and add it to the post confirming the new tag is attached and displayed correctly

## Notes / What's Included

- Added `EditPostTagsDialog` for managing tags on an individual post
- Added `PostTagAside` to display tags alongside post details
- Added client service helpers in `PostTagsService.js` for:
  - fetching tags for a post
  - attaching a tag to a post
  - removing a tag from a post
- Updated `NewPost` so selected tags are attached after post creation
- Updated `PostForm` to support controlled selected tag state via `selectedTagIds`
- Updated `PostDetails` to display post tags and support tag refresh after edits
- Removed tag-loading logic from `EditPost` form flow, shifting tag management to the dedicated tag dialog
- Updated `ConfirmDialog` to better support rich dialog content and long titles
- Updated `DeletePostButton` so admins can delete posts in addition to post owners
- Updated `TagService` to use `putJson` for tag edits
- Exported new post-tag service functions through the shared services index