### PR TITLE
Prevent Loss of All Admins (Ticket #37)

### DIFF
--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -2,6 +2,7 @@ import { useRef } from "react"
 import { Link } from "react-router-dom"
 import { useNavigate } from "react-router-dom"
 import { registerUser } from "../../managers/AuthManager"
+import { getAllUsers } from "../../services/index.js"
 
 export const Register = ({setToken}) => {
   const firstName = useRef()
@@ -14,17 +15,21 @@ export const Register = ({setToken}) => {
   const passwordDialog = useRef()
   const navigate = useNavigate()
 
-  const handleRegister = (e) => {
+  const handleRegister = async (e) => {
     e.preventDefault()
-    
+
     if (password.current.value === verifyPassword.current.value) {
+      const existingUsers = await getAllUsers()
+      const isFirstUser = existingUsers.length === 0
+
       const newUser = {
         username: username.current.value,
         first_name: firstName.current.value,
         last_name: lastName.current.value,
         email: email.current.value,
         password: password.current.value,
-        bio: bio.current.value
+        bio: bio.current.value,
+        is_staff: isFirstUser
       }
 
       registerUser(newUser)

--- a/src/components/users/UserProfiles.jsx
+++ b/src/components/users/UserProfiles.jsx
@@ -93,7 +93,17 @@ export const UserProfiles = () => {
   }, [activeFilter, refreshKey, currentUser.id]);
 
   // Handle activate/deactivate user. Shows confirmation dialog first, then calls API to update user status if confirmed.
+  // Blocks deactivation if the user is the last admin.
   const handleToggleActive = (user) => {
+    if (user.active && user.is_staff) {
+      const adminCount = allUsers.filter((u) => u.is_staff).length;
+      if (adminCount === 1) {
+        setNotification(
+          "You cannot deactivate the last admin. Please promote another user to Admin before making the last admin inactive.",
+        );
+        return;
+      }
+    }
     setSelectedUser(user);
     dialogRef.current.showModal();
   };


### PR DESCRIPTION
# Description

Prevents the application from ending up with zero admins (Ticket #37) by adding extra safeguards during registration and user deactivation.

This updates client-side behavior so the first registered user is automatically assigned admin access, and it blocks deactivation of the last remaining admin from the user management screen.

## Changes

* [ ] Bug fix
* [x] New feature
* [ ] Refactor
* [ ] Documentation update

## Testing

* [x] In a fresh environment with no users, navigate to **Register** create the first user account and confirm the first registered user is created as an **Admin**
* [x] Navigate to the **User Profiles** management page and locate a user who is currently the only admin. Attempt to deactivate that admin
* [x] Confirm a notification appears explaining that the last admin cannot be deactivated
* [x] Add or promote another user to **Admin** and attempt to deactivate one of the admins again to confirm the deactivation flow is allowed once another admin exists

## Notes / What's Included

* Updated `Register.js` to check whether any users already exist before submitting registration
* Automatically marks the first registered user as `is_staff`
* Updated `UserProfiles.jsx` to prevent deactivation of the last remaining admin
* Added a user-facing notification when attempting to deactivate the final admin
* Strengthens existing admin-protection behavior on the client side without introducing a large workflow change
