### PR TITLE
Add post tag filter dropdown to All Posts page

### DIFF
--- a/src/components/posts/AllPosts.jsx
+++ b/src/components/posts/AllPosts.jsx
@@ -7,6 +7,7 @@ import { useCurrentUser } from "../../context/CurrentUserContext.js";
 import { FilterBar } from "../posts/FilterBar.jsx";
 import { Loading, PageHeader, Container, Button } from "../../design";
 import { PostCard } from "./PostCard.jsx";
+import { getAllTags } from "../../services";
 
 export const AllPosts = () => {
   const { currentUser } = useCurrentUser();
@@ -18,10 +19,22 @@ export const AllPosts = () => {
   const [inputValue, setInputValue] = useState("");
   // ADDED (search_post_title ticket): searchTerm only updates when Enter is pressed, this is what actually triggers the filter
   const [searchTerm, setSearchTerm] = useState("");
+  // ADDED (search_post_by_tag ticket): allTags holds the full list of tags fetched from the API for the dropdown
+  const [allTags, setAllTags] = useState([]);
+  // ADDED (search_post_by_tag ticket): selectedTag holds the tag id the user picks from the dropdown, empty string means no tag selected
+  const [selectedTag, setSelectedTag] = useState("");
 
   useEffect(() => {
     getAllPosts().then((allPosts) => {
       setPosts(allPosts);
+      setLoading(false);
+    });
+  }, []);
+
+  // ADDED (search_post_by_tag ticket): Fetch all tags on mount so the dropdown has options to show
+  useEffect(() => {
+    getAllTags().then((allTags) => {
+      setAllTags(allTags);
       setLoading(false);
     });
   }, []);
@@ -54,6 +67,14 @@ export const AllPosts = () => {
       );
     }
 
+    // ADDED (search_post_by_tag ticket): If a tag is selected, keep only posts that have that tag in their tags array
+    // Number() converts the string from the dropdown value back to a number to match t.id
+    if (selectedTag) {
+      filtered = filtered.filter((p) =>
+        p.tags?.some((t) => t.id === Number(selectedTag)),
+      );
+    }
+
     // Send the filtered list back to whoever called this function
     return filtered;
   };
@@ -64,10 +85,14 @@ export const AllPosts = () => {
       <Button className="is-link mb-5" onClick={() => navigate("/posts/new")}>
         New Post
       </Button>
+      {/* ADDED (search_post_by_tag ticket): Passing allTags, selectedTag, setSelectedTag so FilterBar can render the tag dropdown */}
       <FilterBar
         inputValue={inputValue}
         setInputValue={setInputValue}
         onSearch={handleSearch}
+        allTags={allTags}
+        selectedTag={selectedTag}
+        setSelectedTag={setSelectedTag}
       />
       <div className="columns is-multiline">
         {/* CHANGED (search_post_title ticket): Was posts.map — now calls getFilteredPost() first so only matching posts are shown */}

--- a/src/components/posts/FilterBar.jsx
+++ b/src/components/posts/FilterBar.jsx
@@ -1,4 +1,12 @@
-export const FilterBar = ({ inputValue, setInputValue, onSearch }) => {
+export const FilterBar = ({
+  inputValue,
+  setInputValue,
+  onSearch,
+  // ADDED (search_post_by_tag ticket): allTags powers the dropdown options, selectedTag tracks the current selection
+  allTags,
+  selectedTag,
+  setSelectedTag,
+}) => {
   return (
     <div className="filter-bar">
       <input
@@ -8,6 +16,18 @@ export const FilterBar = ({ inputValue, setInputValue, onSearch }) => {
         onChange={(e) => setInputValue(e.target.value)}
         onKeyDown={onSearch}
       />
+      {/* ADDED (search_post_by_tag ticket): Dropdown filters posts by tag — "All Tags" resets the filter */}
+      <select
+        value={selectedTag}
+        onChange={(e) => setSelectedTag(e.target.value)}
+      >
+        <option value="">All Tags</option>
+        {allTags.map((tag) => (
+          <option key={tag.id} value={tag.id}>
+            {tag.label}
+          </option>
+        ))}
+      </select>
     </div>
   );
 };


### PR DESCRIPTION
# Description

Added tag filtering functionality to the All Posts page. Users can select a tag from a dropdown to filter the displayed posts. The backend was updated to include a tags array on each post object using a SQL JOIN on the PostTags table. The frontend was extended with a tag dropdown in the existing FilterBar component and a second filter condition in getFilteredPost().

## Changes

- [ ] Bug fix  
- [X] New feature  

## Testing

Navigated to /posts — all posts displayed as expected
Opened the tag dropdown — all available tags appeared as options
Selected a tag — only posts with that tag were displayed
Selected "All Tags" — all posts returned
Used title search and tag dropdown together — both filters applied simultaneously
Created a new post with tags assigned, then filtered by that tag — post appeared correctly

## Notes


