### PR TITLE
Add reaction bar with Slack-style overflow dialog and staff-only create reaction form

### DIFF
--- a/src/components/reactions/CreateReactionForm.jsx
+++ b/src/components/reactions/CreateReactionForm.jsx
@@ -1,0 +1,89 @@
+import { useState } from "react"
+import { createReaction } from "../../services"
+
+export const CreateReactionForm = ({ onReactionCreated, onCancel }) => {
+  const [newReaction, setNewReaction] = useState({ label: "", icon_class: "", color: "#000000" })
+  const [saving, setSaving] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!newReaction.label.trim() || !newReaction.icon_class.trim()) return
+
+    setSaving(true)
+    try {
+      await createReaction(newReaction)
+      onReactionCreated()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <p className="label mb-2">Create New Reaction</p>
+      <div className="field">
+        <label className="label is-small">Label</label>
+        <div className="control">
+          <input
+            className="input"
+            type="text"
+            placeholder="e.g. Love"
+            value={newReaction.label}
+            onChange={(e) =>
+              setNewReaction({ ...newReaction, label: e.target.value })
+            }
+            required
+          />
+        </div>
+      </div>
+      <div className="field">
+        <label className="label is-small">Icon Class</label>
+        <div className="control">
+          <input
+            className="input"
+            type="text"
+            placeholder="e.g. fas fa-heart"
+            value={newReaction.icon_class}
+            onChange={(e) =>
+              setNewReaction({ ...newReaction, icon_class: e.target.value })
+            }
+            required
+          />
+        </div>
+        {newReaction.icon_class && (
+          <p className="help">
+            Preview: <i className={newReaction.icon_class} style={{ color: newReaction.color }}></i>
+          </p>
+        )}
+      </div>
+      <div className="field">
+        <label className="label is-small">Color</label>
+        <div className="control">
+          <input
+            type="color"
+            value={newReaction.color}
+            onChange={(e) =>
+              setNewReaction({ ...newReaction, color: e.target.value })
+            }
+          />
+        </div>
+      </div>
+      <div className="buttons">
+        <button
+          type="submit"
+          className={`button is-success ${saving ? "is-loading" : ""}`}
+          disabled={saving}
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          className="button"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/reactions/ReactionBar.jsx
+++ b/src/components/reactions/ReactionBar.jsx
@@ -6,6 +6,9 @@ import {
   getPostReactionsByPostId,
   updateOrCreatePostReaction,
 } from "../../services"
+import { ReactionPickerDialog } from "./ReactionPickerDialog"
+
+const MAX_VISIBLE_REACTIONS = 5
 
 export const ReactionBar = ({ postId, size = "small" }) => {
   const { currentUser } = useCurrentUser()
@@ -15,6 +18,7 @@ export const ReactionBar = ({ postId, size = "small" }) => {
   const [loading, setLoading] = useState(true)
   const [popReactionId, setPopReactionId] = useState(null)
   const [workingReactionId, setWorkingReactionId] = useState(null)
+  const [showDialog, setShowDialog] = useState(false)
 
   // useRef hook is used here to store the timer ID for the pop animation
   // It allows us to clear it if the user clicks multiple times quickly without causing unnecessary re-renders
@@ -92,11 +96,22 @@ export const ReactionBar = ({ postId, size = "small" }) => {
     }
   }
 
+  const handleReactionCreated = async () => {
+    const types = await getAllReactions()
+    setReactionTypes(types)
+  }
+
   if (loading) return <Loading />
+
+  const sortedReactions = [...reactionTypes].sort(
+    (a, b) => (countsByReactionId[b.id] || 0) - (countsByReactionId[a.id] || 0)
+  )
+  const visibleReactions = sortedReactions.slice(0, MAX_VISIBLE_REACTIONS)
+  const overflowReactions = sortedReactions.slice(MAX_VISIBLE_REACTIONS)
 
   return (
     <div className="tags are-medium">
-      {reactionTypes.map((rt) => {
+      {visibleReactions.map((rt) => {
         const count = countsByReactionId[rt.id] || 0
         const isSelected = myReactionId === rt.id
         const isWorking = workingReactionId === rt.id
@@ -116,7 +131,7 @@ export const ReactionBar = ({ postId, size = "small" }) => {
             title={currentUser ? rt.label : "Log in to react"}
           >
             <span className="icon is-small mr-1">
-              <i className={rt.icon_class} 
+              <i className={rt.icon_class}
               style={{color: isSelected ? rt.color : "#b5b5b5"}}>
               </i>
             </span>
@@ -125,6 +140,30 @@ export const ReactionBar = ({ postId, size = "small" }) => {
           </Tag>
         )
       })}
+
+      <Tag
+        rounded
+        light
+        className="reaction-tag add-reaction-tag"
+        onClick={() => setShowDialog(true)}
+        style={{ cursor: "pointer", userSelect: "none" }}
+        title="More reactions"
+      >
+        <span className="icon is-small">
+          <i className="fas fa-plus" style={{ color: "#b5b5b5" }}></i>
+        </span>
+      </Tag>
+
+      {showDialog && (
+        <ReactionPickerDialog
+          overflowReactions={overflowReactions}
+          countsByReactionId={countsByReactionId}
+          myReactionId={myReactionId}
+          onSelect={handleReact}
+          onReactionCreated={handleReactionCreated}
+          onClose={() => setShowDialog(false)}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/reactions/ReactionPickerDialog.jsx
+++ b/src/components/reactions/ReactionPickerDialog.jsx
@@ -1,0 +1,126 @@
+import { useRef, useState } from "react"
+import { useCurrentUser } from "../../context/CurrentUserContext"
+import { Tag } from "../../design"
+import { CreateReactionForm } from "./CreateReactionForm"
+
+export const ReactionPickerDialog = ({
+  overflowReactions,
+  countsByReactionId,
+  myReactionId,
+  onSelect,
+  onReactionCreated,
+  onClose,
+}) => {
+  const { currentUser } = useCurrentUser()
+  const dialogRef = useRef(null)
+  const [showCreateForm, setShowCreateForm] = useState(false)
+
+  // Open the native dialog on mount
+  useState(() => {
+    setTimeout(() => dialogRef.current?.showModal(), 0)
+  })
+
+  const closeDialog = () => {
+    dialogRef.current?.close()
+    onClose()
+  }
+
+  const handleSelect = (reactionId) => {
+    onSelect(reactionId)
+    closeDialog()
+  }
+
+  const handleReactionCreated = () => {
+    onReactionCreated()
+    closeDialog()
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onCancel={(e) => {
+        e.preventDefault()
+        closeDialog()
+      }}
+    >
+      <div className="modal is-active">
+        <div className="modal-background" onClick={closeDialog}></div>
+        <div className="modal-card">
+          <header className="modal-card-head">
+            <p className="modal-card-title">Reactions</p>
+            <button
+              type="button"
+              className="delete"
+              aria-label="close"
+              onClick={closeDialog}
+            ></button>
+          </header>
+
+          <section className="modal-card-body">
+            {overflowReactions.length > 0 && (
+              <>
+                <p className="label mb-2">More Reactions</p>
+                <div className="tags are-medium" style={{ flexWrap: "wrap" }}>
+                  {overflowReactions.map((rt) => {
+                    const count = countsByReactionId[rt.id] || 0
+                    const isSelected = myReactionId === rt.id
+
+                    return (
+                      <Tag
+                        key={rt.id}
+                        rounded
+                        light
+                        className={`reaction-tag ${isSelected ? "reaction-selected" : ""}`}
+                        onClick={() => handleSelect(rt.id)}
+                        style={{ cursor: "pointer", userSelect: "none" }}
+                        title={rt.label}
+                      >
+                        <span className="icon is-small mr-1">
+                          <i
+                            className={rt.icon_class}
+                            style={{ color: isSelected ? rt.color : "#b5b5b5" }}
+                          ></i>
+                        </span>
+                        <span className="mr-1">{rt.label}</span>
+                        <span>{count}</span>
+                      </Tag>
+                    )
+                  })}
+                </div>
+              </>
+            )}
+
+            {currentUser?.is_staff && (
+              <>
+                {overflowReactions.length > 0 && <hr />}
+                {!showCreateForm ? (
+                  <button
+                    type="button"
+                    className="button is-link is-light"
+                    onClick={() => setShowCreateForm(true)}
+                  >
+                    <span className="icon is-small mr-1">
+                      <i className="fas fa-plus"></i>
+                    </span>
+                    <span>Create New Reaction</span>
+                  </button>
+                ) : (
+                  <CreateReactionForm
+                    onReactionCreated={handleReactionCreated}
+                    onCancel={() => setShowCreateForm(false)}
+                  />
+                )}
+              </>
+            )}
+          </section>
+
+          <footer className="modal-card-foot">
+            <button type="button" className="button" onClick={closeDialog}>
+              Close
+            </button>
+          </footer>
+        </div>
+      </div>
+    </dialog>
+  )
+}

--- a/src/design/design.css
+++ b/src/design/design.css
@@ -78,3 +78,16 @@
     opacity: 0;
   }
 }
+
+/* Add reaction button */
+.add-reaction-tag {
+  border: 1px dashed #b5b5b5;
+}
+
+.add-reaction-tag:hover {
+  border-color: #4a4a4a;
+}
+
+.add-reaction-tag:hover i {
+  color: #4a4a4a !important;
+}

--- a/src/services/ReactionService.js
+++ b/src/services/ReactionService.js
@@ -1,5 +1,9 @@
-import { fetchJson } from "./apiSettings";
+import { fetchJson, postJson } from "./apiSettings";
 
 export function getAllReactions() {
     return fetchJson("/reactions");
+}
+
+export function createReaction(reaction) {
+    return postJson("/reactions", reaction);
 }

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -31,7 +31,7 @@ export {
 export { getCommentsByPostId, createComment } from "./CommentService.js";
 
 // Reactions
-export { getAllReactions } from "./ReactionService.js";
+export { getAllReactions, createReaction } from "./ReactionService.js";
 
 // PostReactions
 export {


### PR DESCRIPTION

# Description

Implements the full reaction UX for posts. The ReactionBar displays up to 5 reaction types sorted by count, with a + button that opens a modal dialog showing overflow reactions and (for staff) a form to create new reaction types. Reacting toggles the current user's reaction via PUT /postreactions. The create form POSTs to /reactions with a label, Font Awesome icon class, and color picker — with a live icon preview.

## Changes

- [ ] Bug fix  
- [x] New feature  

## Testing

Test Plan
Reaction bar display
[ ] -  Navigate to a post — reaction bar renders beneath the post
[ ] -  Reactions are sorted by count (most reacted first)
[ ] -  Only 5 reactions max are shown in the bar; the rest appear in the dialog
[ ] -  Reactions with 0 count still appear (just showing 0)

Reacting to a post
[ ]  Click a reaction tag — count increments and the icon becomes colored
[ ]  Click the same reaction again — it toggles off (count decrements, icon goes grey)
[ ]  Click a different reaction — switches your reaction
[ ]  A brief +1 pop animation appears on click
[ ]  While a reaction is saving, the tag shows 0.6 opacity and double-clicking is blocked

Overflow dialog
[ ]  Clicking the + button opens the Reactions modal
[ ]  Overflow reactions (beyond 5) appear in the dialog with label and count
[ ]  Clicking a reaction in the dialog applies it and closes the modal
[ ]  Clicking the modal backdrop or the × button closes the dialog
[ ]  Pressing Escape closes the dialog


Create new reaction (staff only)
[ ]  Log in as a staff user — "Create New Reaction" button is visible in the dialog
[ ]  Log in as a non-staff user — "Create New Reaction" button is not visible
[ ]  Clicking "Create New Reaction" expands the inline form
[ ]  Typing an icon class (e.g. fas fa-heart) shows a live preview below the input
[ ]  Color picker updates the preview icon color in real time
[ ]  Submitting with a blank label or icon class is blocked (HTML required)
[ ]  Successful submit closes the dialog and the new reaction appears in the bar
[ ]  "Cancel" collapses the form without creating a reaction
[ ]  Save button shows a loading spinner while the request is in flight