### PR TITLE
Added Tandem and README.md to the project repo

### DIFF
--- a/.claude/commands/create-adr.md
+++ b/.claude/commands/create-adr.md
@@ -1,0 +1,77 @@
+---
+description: Record an architecture decision. Creates a numbered ADR documenting the context, decision, alternatives considered, and consequences.
+argument-hint: [decision title or description] (optional)
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Create ADR
+
+You are helping a developer record an architecture decision. ADRs capture the context behind significant technical decisions so the team (or future self) can understand why a choice was made.
+
+## Workflow
+
+### Step 1: Gather Context
+
+If the developer provided a description: $ARGUMENTS
+
+Understand the decision:
+- What situation or problem prompted this decision?
+- What did you decide?
+- What alternatives were considered and why were they rejected?
+- What are the consequences (positive and negative)?
+
+If this was triggered as a suggestion from `/update-docs`, pull the context from that conversation.
+
+### Step 2: Find the ADR Directory
+
+Check `tandem.json` for an entry tagged `adr`. This tells you where ADRs live.
+
+- If found, use that path.
+- If not found, default to `dev-docs/adrs/`. Create the directory if it doesn't exist.
+- Auto-number by scanning existing ADR files in the directory. Use zero-padded three-digit numbers (001, 002, 003).
+
+### Step 3: Write the ADR
+
+```markdown
+# ADR-[NNN]: [Decision Title]
+
+**Date:** [date]
+**Status:** Accepted
+
+## Context
+[What situation or problem prompted this decision?]
+
+## Decision
+[What did you decide?]
+
+## Alternatives Considered
+[What other options were evaluated and why were they rejected?]
+
+## Consequences
+[What are the implications of this decision, both positive and negative?]
+```
+
+Keep it short. If it takes more than 10 minutes to write, it's too long.
+
+### Step 4: Update Architecture Doc
+
+Check `tandem.json` for a doc tagged `architecture`. If one exists, update its Key Technical Decisions section to reference the new ADR. If no architecture doc exists, skip this step.
+
+### Step 5: Register ADR Directory (If New)
+
+If the ADR directory wasn't already in `tandem.json`, add it:
+
+```json
+{
+  "path": "dev-docs/adrs/",
+  "scope": "general",
+  "purpose": "Architecture decision records",
+  "tags": ["adr", "decisions"]
+}
+```
+
+## Important Reminders
+
+- ADRs are immutable once accepted. If a decision is reversed, write a new ADR that supersedes the old one. Don't edit the original.
+- ADRs own **why a specific technical choice was made**. The architecture doc summarizes; the ADR has the full reasoning.
+- Never use em dashes in any written content. Use commas, periods, colons, or semicolons instead.

--- a/.claude/commands/create-architecture.md
+++ b/.claude/commands/create-architecture.md
@@ -1,0 +1,150 @@
+---
+description: Generate or reverse-engineer a technical architecture document. Works for new projects (design), existing codebases (reverse-engineer), or migrations (current + target state).
+argument-hint: [design|reverse-engineer|migration] (optional)
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+# Create Architecture
+
+You are helping a developer create a technical architecture document. This skill works in three modes depending on the project situation.
+
+**Use AskUserQuestion for structured decisions.** When the conversation reaches a decision point with discrete options (which mode to use, component trade-offs, infrastructure choices, "include this section or not?"), use the AskUserQuestion tool to present labeled options with descriptions. This is clearer than free-text for architectural trade-off discussions. Keep open-ended exploration as regular conversation.
+
+## Detect Mode
+
+Determine which mode to use:
+
+1. **Check `tandem.json`** for a doc tagged `prd`. Check if the project has existing code (source files, not just config).
+2. If there's a PRD but no existing code: **design mode** (greenfield).
+3. If there's an existing codebase: **reverse-engineer mode** (brownfield).
+4. If there's both existing code and a PRD or target state description: **migration mode** (bluefield).
+5. If ambiguous, ask: "Are we designing something new, mapping an existing system, or planning a migration?"
+6. If the developer provided an argument ($ARGUMENTS), respect it.
+
+## Mode 1: Design (Greenfield)
+
+The developer has a PRD and needs to design a system.
+
+1. **Read the PRD** (found via manifest, tagged `prd`).
+2. **Read `~/.claude/CLAUDE.md`** if it has a Developer Profile. Use experience level to calibrate discussion depth. Do NOT let the developer's existing stack influence recommendations; design for the project's needs.
+3. **Discuss the architecture.** Walk through major components, data model, API design, and infrastructure. This is collaborative; the developer should understand and agree with the decisions.
+4. **Draft the architecture doc** (default: `dev-docs/ARCHITECTURE.md`, or wherever the developer specifies).
+5. **Register in manifest** and review with the developer.
+
+**Important:** In design mode, do NOT include the Codebase Map or Entry Points sections (there's no code yet). These get added later via `/update-docs` once development is underway.
+
+## Mode 2: Reverse-Engineer (Brownfield)
+
+The developer has an existing codebase they need to understand.
+
+1. **Scan the codebase.** Adapt depth based on project size:
+   - **Small (<20 files):** Scan into individual files. Read route handlers, model definitions, key utility functions. The full picture fits in context.
+   - **Medium (20-100 files):** Scan directory structure fully. Read entry points and config in full. Read key files (models, routes, main modules) but summarize rather than reproduce. Skim utility files and tests for patterns.
+   - **Large (100+ files):** Start with directory structure and package manifests only. Read entry points, config, and README. Identify major modules and read their top-level files. Go deeper only where the developer asks.
+   - When in doubt, start broad: "This is a large codebase. Want me to go deeper into any specific area?"
+2. **Draft the architecture doc.** Include Codebase Map and Entry Points sections from the start.
+3. **Add Unanswered Questions** if you encounter things you can't determine from the code alone (why a pattern was chosen, what a cryptic config does, whether code is still in use). Keep this minimal: only questions that materially affect the developer's ability to work in the codebase.
+4. **Register in manifest** and review with the developer. Review is especially important here: the developer can correct misunderstandings about how the system works.
+
+## Mode 3: Migration (Bluefield)
+
+The developer has an existing codebase that needs to evolve.
+
+1. **Reverse-engineer the current state** (same as Mode 2).
+2. **Understand the target state** from the developer's description or PRD.
+3. **Draft the architecture doc** with additional sections:
+   - "Current State" and "Target State" for each component that's changing.
+   - A "Migration Path" section: what changes in what order.
+4. **Add Unanswered Questions** (same as Mode 2).
+5. **Register in manifest** and review with the developer.
+
+## Architecture Doc Template
+
+Use this as a flexible starting point. Adapt sections based on the project.
+
+```markdown
+<!-- Last updated: [date] -->
+<!-- Last change: Initial architecture document -->
+
+# [Project Name] - Technical Architecture
+
+## System Overview
+[High-level description of the system]
+
+[Mermaid system diagram showing major components and how they communicate]
+
+## Codebase Map
+[Annotated directory structure: what each directory and key file is responsible for.
+Only include in reverse-engineer/migration modes, or added later via /update-docs.]
+
+## Entry Points
+[How the app starts, what gets called first, where the request lifecycle begins.
+Only include in reverse-engineer/migration modes, or added later via /update-docs.]
+
+## Component Breakdown
+[Each component, its responsibility, how it communicates with others]
+
+## Data Model
+[Full schema: tables/collections, columns/fields with types, relationships,
+constraints, indexes.]
+
+[Mermaid ERD showing entities, attributes with types, and relationships]
+
+## API Design
+[Endpoints overview, patterns, auth approach]
+
+## Infrastructure & Deployment
+[Hosting, CI/CD, environments]
+
+## Key Technical Decisions
+[Brief summary; detailed rationale lives in ADRs]
+
+## Project Conventions (optional)
+[Cross-cutting rules for how code is written in this project.
+Keep this short: if it doesn't fit on one page, something belongs elsewhere.]
+
+### Development Philosophy
+[Project-specific principles. Overrides or extends the developer's global
+philosophy from their Developer Profile.]
+
+### Testing
+[Strategy, framework, what gets tested, coverage expectations]
+
+### Code Style
+[Type hints, import style, naming conventions, patterns to prefer/avoid]
+
+### Error Handling
+[Structured responses, logging, what never to swallow silently]
+
+### Commits & PRs
+[Conventional commits, PR requirements, review process]
+
+### AI Rules
+[Any rules specific to how AI agents should behave in this codebase]
+```
+
+## Diagrams
+
+- **System Overview** always includes a Mermaid diagram showing major components (frontend, backend, database, external services) and how they connect.
+- **Data Model** includes a Mermaid ERD showing the full schema: entities, attributes with types, and relationships. This should reflect the actual database schema, not just a conceptual model.
+- Generate diagrams in Mermaid syntax so they render in GitHub, VS Code, and most markdown viewers.
+
+## Register in Manifest
+
+After writing the doc, update `tandem.json`:
+
+```json
+{
+  "path": "dev-docs/ARCHITECTURE.md",
+  "scope": "general",
+  "purpose": "System design, component breakdown, data model, API design, project conventions",
+  "tags": ["architecture", "system-design", "conventions", "data-model"]
+}
+```
+
+## Important Reminders
+
+- The architecture doc owns **how to build it**. What to build and why belongs in the PRD.
+- The goal is always a useful mental model, not an exhaustive catalog. A Codebase Map that's 10 pages long is worse than one that's 1 page with the right information.
+- The Unanswered Questions section is temporary. It gets resolved and removed over time.
+- Never use em dashes in any written content. Use commas, periods, colons, or semicolons instead.

--- a/.claude/commands/create-issues.md
+++ b/.claude/commands/create-issues.md
@@ -1,0 +1,90 @@
+---
+description: Convert roadmap steps into GitHub issues with two-way linking. Requires GitHub CLI (gh) to be installed and authenticated.
+argument-hint: (no arguments)
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Create Issues
+
+You are helping a developer convert their roadmap steps into GitHub issues. Each issue links back to its roadmap step, and each roadmap step gets updated with a link to its issue.
+
+## Prerequisites
+
+1. **A roadmap must exist.** Check `tandem.json` for a doc tagged `roadmap`. If none exists:
+   > "I need a roadmap to create issues from. Want to run `/create-roadmap` first?"
+
+2. **The project must be a GitHub repo.** Check for `.git/` directory and a GitHub remote.
+
+3. **GitHub CLI must be installed and authenticated.** Test with `gh auth status`. If not available:
+   > "This command requires the GitHub CLI (`gh`) to be installed and authenticated. Install it at https://cli.github.com/ and run `gh auth login`."
+
+## Workflow
+
+### Step 1: Read the Roadmap
+
+Find the roadmap via the manifest (tagged `roadmap`). Parse each step: title, description, user stories (if any).
+
+### Step 2: Preview Issues
+
+Present the issues that will be created:
+
+> "I'll create these GitHub issues from your roadmap:"
+>
+> 1. **Step 1: [Title]** - [brief description]
+> 2. **Step 2: [Title]** - [brief description]
+> ...
+>
+> "Want to proceed, or adjust anything first?"
+
+Wait for confirmation.
+
+### Step 3: Create Issues
+
+For each roadmap step, create a GitHub issue using `gh issue create`. Use the issue template from `.tandem/templates/github-issue.md` if it exists, otherwise use this format:
+
+```markdown
+## Description
+[What this step implements, pulled from the roadmap step description]
+
+## User Stories (if applicable)
+[Pulled from the roadmap step, if user stories were included]
+- As a [user type], I want to [action] so that [outcome].
+
+## Roadmap Reference
+Step [N] in `[roadmap path from tandem.json]`
+
+## Acceptance Criteria
+- [ ] [Key deliverable or behavior that signals this step is done]
+- [ ] [Another criteria if applicable]
+```
+
+Derive acceptance criteria from the roadmap step's description and user stories. Keep them concrete and verifiable.
+
+### Step 4: Update Roadmap with Issue Links
+
+After creating each issue, update the corresponding roadmap step to include a link:
+
+```markdown
+- [ ] **Step 1: [Title]**
+  [Description]
+  GitHub Issue: #12
+```
+
+This creates true two-way references: issues link to roadmap steps, roadmap steps link to issues. When `/update-docs` modifies a roadmap step later, it can see the linked issue and flag that it may be out of date.
+
+### Step 5: Summary
+
+Report what was created:
+
+> "Created [N] GitHub issues:"
+> - #12: Step 1 - [Title]
+> - #13: Step 2 - [Title]
+> ...
+>
+> "Each issue links back to its roadmap step, and each roadmap step now links to its issue."
+
+## Important Reminders
+
+- Issues are for workflow organization, not learning classification. No learning tier labels or learning goal tags. `/pair-program` handles learning-aware guidance during implementation.
+- Just issues, not a project board. The developer creates their own board if they want one.
+- Never use em dashes in any written content. Use commas, periods, colons, or semicolons instead.

--- a/.claude/commands/create-manifest.md
+++ b/.claude/commands/create-manifest.md
@@ -1,0 +1,125 @@
+---
+description: Generate or update the tandem.json project manifest. Scans for existing docs (brownfield) or creates a minimal manifest (greenfield).
+argument-hint: [scan|init] (optional)
+allowed-tools: Read, Write, Bash, Glob, Grep
+---
+
+# Create Manifest
+
+You are helping a developer set up or update their `tandem.json` project manifest. This file is the table of contents for all project documentation: what docs exist, what they cover, and where they live.
+
+## Detect Mode
+
+First, determine which mode to use:
+
+1. **Check if `tandem.json` already exists** in the project root.
+   - If it exists, offer to **update** it by scanning for new docs that aren't already in the manifest. Do not overwrite existing entries.
+
+2. **Check if the project has existing documentation files** (markdown files in `docs/`, `wiki/`, `.claude/rules/`, project root, etc.; README files; ADR directories).
+   - If yes, use **scan mode**.
+   - If the project is empty or brand new with no documentation, use **initialize mode**.
+
+3. If the user provided an argument ($ARGUMENTS), respect it: "scan" forces scan mode, "init" forces initialize mode.
+
+## Scan Mode (Brownfield/Bluefield)
+
+The project already has documentation. Your job is to find it, categorize it, and build the manifest.
+
+### Step 1: Scan for documentation files
+
+
+Search the repo for documentation files. Do NOT use a single unscoped recursive glob like `**/*.md` from the project root, as results will be dominated and truncated by dependency directories.
+
+**Search strategy (in this order):**
+
+1. **Project root first:** `Glob("*.md", path=projectRoot)` to catch top-level docs like README.md, DEPLOY.md, CONTRIBUTING.md, etc. These are the most commonly missed.
+2. **Known doc directories:** Glob `**/*.md` scoped within each of: `docs/`, `wiki/`, `dev-docs/`, `.github/`, `.claude/rules/`, and any `adr/` or `adrs/` directory.
+3. **Catch-all with exclusions:** Use Bash with `find` to locate remaining markdown files while excluding dependency and build directories. Exclude paths containing: `node_modules`, `.git`, `vendor`, `build`, `dist`, `__pycache__`, `.venv`, `venv`, and `.claude/commands`. Compare against files already found in steps 1-2 to identify docs in unexpected locations.
+
+**Look for:**
+- README files, contributing guides, style guides, convention docs
+- Architecture and design documents
+- Config documentation, deployment guides
+- ADR (Architecture Decision Record) files
+
+**Be conservative.** Exclude:
+- Files inside `node_modules/`, `.git/`, `vendor/`, `build/`, `dist/`, `__pycache__/`, `.venv/`, `venv/`
+- LICENSE files
+- Changelog/release notes (unless specifically about architecture or conventions)
+- Auto-generated docs
+- Package README files that aren't project documentation
+- Tandem skill/command templates (`.claude/commands/`)
+
+For large repos with many markdown files, prioritize: architecture docs, API docs, convention/style guides, ADRs, READMEs, and contribution guides. If you find more than 20 documentation files, ask the developer: "I found [N] markdown files. Want me to include all of them, or should I focus on the most important ones?"
+
+### Step 2: Categorize each file
+
+For each file found, infer these fields by reading the filename, directory, and first few lines or headings:
+
+- **`path`**: Relative path from project root
+- **`scope`**: Which domain this doc covers. Common values: `general` (applies to everything), `frontend`, `backend`, `database`, `api`, `infrastructure`. Use whatever values fit the project.
+- **`purpose`**: A human-readable description of what the doc contains. This is what other Tandem commands read to decide relevance without opening the file.
+- **`tags`**: Finer-grained matching keywords. Conventional tags that other Tandem commands search for: `prd`, `architecture`, `roadmap`, `adr`, `conventions`.
+
+### Step 3: Present for review
+
+Show the developer the draft manifest:
+
+> "I found these docs in your repo. Here's how I'd categorize them. Want to adjust anything?"
+
+Display the full JSON so they can see every entry. Wait for feedback and revise before writing.
+
+### Step 4: Write the manifest
+
+Write `tandem.json` to the project root with the reviewed entries:
+
+```json
+{
+  "version": 1,
+  "config": {
+    "understandingChecks": true
+  },
+  "docs": [
+    {
+      "path": "path/to/doc.md",
+      "scope": "general",
+      "purpose": "Description of what this doc contains",
+      "tags": ["relevant", "tags"]
+    }
+  ]
+}
+```
+
+## Initialize Mode (Greenfield)
+
+The project is new with no documentation. Create a minimal manifest:
+
+```json
+{
+  "version": 1,
+  "config": {
+    "understandingChecks": true
+  },
+  "docs": []
+}
+```
+
+Write this to `tandem.json` in the project root and let the developer know:
+
+> "Created `tandem.json` with default config and an empty docs array. As you create documentation with `/create-prd`, `/create-architecture`, etc., each command will register its output in the manifest automatically."
+
+## Update Mode (Existing Manifest)
+
+If `tandem.json` already exists:
+
+1. Read the current manifest.
+2. Scan the repo for documentation files (same as scan mode).
+3. Compare against existing entries. Identify new files not yet in the manifest.
+4. Present only the new files to the developer: "I found these docs that aren't in your manifest yet. Want to add any of them?"
+5. Add confirmed entries without modifying existing ones.
+
+## Important Reminders
+
+- The manifest is a table of contents, not a format enforcer. It tells Tandem where docs are and what they're about. It says nothing about how they're structured inside.
+- The developer can always edit `tandem.json` manually. This command is a convenience, not a requirement.
+- Never use em dashes in any written content. Use commas, periods, colons, or semicolons instead.

--- a/.claude/commands/create-prd.md
+++ b/.claude/commands/create-prd.md
@@ -1,0 +1,81 @@
+---
+description: Generate a Product Requirements Document from a project idea. Conversational process to gather requirements, discuss trade-offs, and define scope.
+argument-hint: [project idea or description] (optional)
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+# Create PRD
+
+You are helping a developer define their project through a Product Requirements Document. This is a conversational process: gather requirements, discuss trade-offs, explore scope, and produce a concise document that serves as the source of truth for what to build and why.
+
+## Step 1: Gather Context
+
+If the developer provided a description: $ARGUMENTS
+
+Start by understanding the project. Ask clarifying questions. Don't ask everything at once; have a natural conversation. Key things to learn:
+
+- What problem does this solve?
+- Who are the users? (if applicable; not every project has end users)
+- What are the constraints? (timeline, team size, hosting, budget, compliance)
+- Is there a preferred tech stack, or is that open for discussion?
+- Is this a personal/portfolio project or production/client work?
+
+**Read `~/.claude/CLAUDE.md`** if it exists and has a `## Developer Profile` section. Use the developer's experience level to calibrate the depth of your questions and discussion.
+
+**Tech stack neutrality is critical.** Do NOT use the developer's existing tech stack or learning goals from their Developer Profile to influence tool or language recommendations. The right stack for the project is whatever best solves the problem, not whatever the developer already knows or wants to learn. If the developer asks for guidance, recommend tools based on the project's needs, trade-offs, and constraints. Present options and let the developer decide.
+
+**Use AskUserQuestion for structured decisions.** When the conversation reaches a decision point with discrete options (tech stack choices, scope trade-offs, "include this section or not?"), use the AskUserQuestion tool to present labeled options with descriptions. This is clearer than free-text for trade-off discussions. Keep open-ended discovery ("tell me about the problem") as regular conversation.
+
+## Step 2: Draft the PRD
+
+Once you have enough context, draft the PRD. Default location: `dev-docs/PRD.md`, or wherever the developer specifies.
+
+Use this as a flexible starting point, not a rigid format. Adapt sections based on the project. A simple CLI tool doesn't need a Target Users section. A complex distributed system might need additional sections for data flow or security.
+
+```markdown
+<!-- Last updated: [date] -->
+<!-- Last change: Initial PRD creation -->
+
+# [Project Name] - Product Requirements Document
+
+## Problem Statement
+## Target Users (if applicable)
+## Core Requirements
+## Technical Stack
+  ### Stack Decisions (with brief rationale for each)
+## Scope
+  ### In Scope (v1)
+  ### Out of Scope (future)
+## Success Criteria
+## Learning Goals (optional, for personal/portfolio projects only)
+```
+
+**On the Learning Goals section:** Include it only when the developer is building something specifically to learn (a portfolio project, a personal experiment). Leave it out for production work, client projects, or anything where learning is secondary to shipping. If present, `/pair-program` uses it to inform understanding checks. It should never influence which tools or technologies are chosen for the project.
+
+Keep the PRD concise. If it takes more than 10-15 minutes to read, it's too long.
+
+## Step 3: Register in Manifest
+
+After writing the PRD, update `tandem.json`:
+
+- If `tandem.json` exists, add the new doc entry to the `docs` array.
+- If `tandem.json` does not exist, create it with default config and the new doc entry.
+
+```json
+{
+  "path": "dev-docs/PRD.md",
+  "scope": "general",
+  "purpose": "Product requirements, target users, tech stack decisions, project scope",
+  "tags": ["prd", "requirements", "scope", "stack"]
+}
+```
+
+## Step 4: Review with Developer
+
+Walk through the draft with the developer. Get feedback and revise. The PRD is a living document; `/update-docs` can modify it later as things evolve.
+
+## Important Reminders
+
+- The PRD owns **what to build and why**. Architecture (how to build it) belongs in the architecture doc.
+- Brief tech stack rationale goes here. Detailed trade-off analysis goes in ADRs.
+- Never use em dashes in any written content. Use commas, periods, colons, or semicolons instead.

--- a/.claude/commands/create-roadmap.md
+++ b/.claude/commands/create-roadmap.md
@@ -1,0 +1,84 @@
+---
+description: Generate an ordered implementation plan from a PRD. Breaks the project into steps with checkboxes that pair-program uses to track progress.
+argument-hint: (no arguments)
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Create Roadmap
+
+You are helping a developer break their project into an ordered implementation plan. Each step becomes a unit of work for `/pair-program`.
+
+## Prerequisites
+
+A PRD must exist. Check `tandem.json` for a doc tagged `prd`. If none exists, tell the developer:
+
+> "I need a PRD to create a roadmap from. Want to run `/create-prd` first?"
+
+## Workflow
+
+### Step 1: Read Context
+
+1. **Read the PRD** (found via manifest, tagged `prd`).
+2. **Read the architecture doc** if one exists (tagged `architecture`). This informs the order and scope of steps.
+3. **Read `~/.claude/CLAUDE.md`** if it has a Developer Profile. The skill tiers (Currently Learning, Deepening, Strong Skills) may lightly inform step ordering: put foundational setup before topics the developer is actively learning, so they have context before hitting unfamiliar territory.
+
+### Step 2: Break Into Steps
+
+Decompose the project into ordered implementation steps. Each step should be:
+
+- **Ordered by dependency:** What has to exist before what.
+- **Completable in one session:** Roughly 1-4 hours of work per step.
+- **Focused:** Each step has a clear deliverable.
+
+Include user stories where applicable. Not every step has them: infrastructure setup, configuration, and refactoring steps often don't map to a user-facing outcome. But for steps that deliver user-visible functionality, user stories ground the work.
+
+### Step 3: Write the Roadmap
+
+Default location: `dev-docs/ROADMAP.md`, or wherever the developer specifies.
+
+```markdown
+<!-- Last updated: [date] -->
+<!-- Last change: Initial roadmap creation -->
+
+# [Project Name] - Implementation Roadmap
+
+Generated from: [PRD path from tandem.json]
+
+## Steps
+
+- [ ] **Step 1: [Title]**
+  [Brief description of what this step covers and what the deliverable is]
+  [Reference to architecture component if applicable]
+
+  **User Stories** (where applicable):
+  - As a [user type], I want to [action] so that [outcome].
+
+- [ ] **Step 2: [Title]**
+  [Brief description]
+
+...
+```
+
+### Step 4: Register in Manifest
+
+Update `tandem.json`:
+
+```json
+{
+  "path": "dev-docs/ROADMAP.md",
+  "scope": "general",
+  "purpose": "Ordered implementation steps with checkboxes and user stories",
+  "tags": ["roadmap", "planning"]
+}
+```
+
+### Step 5: Review with Developer
+
+Walk through the roadmap. Get feedback on ordering, scope, and step size. Revise as needed.
+
+## Design Notes
+
+- Keep steps minimal. No time estimates or complexity scores.
+- The checkbox format (`- [ ]` / `- [x]`) is what `/pair-program` uses to mark steps complete.
+- Steps can reference specific architecture components when it adds clarity, but this isn't required. `/pair-program` reads both documents regardless.
+- Never use em dashes in any written content. Use commas, periods, colons, or semicolons instead.

--- a/.claude/commands/pair-program.md
+++ b/.claude/commands/pair-program.md
@@ -1,0 +1,152 @@
+---
+description: Guided pair programming with understanding checks. Break work into sub-steps, explain each one, verify understanding before moving on.
+argument-hint: [task description, roadmap step, or issue number]
+allowed-tools: Read, Edit, Write, Bash, Glob, Grep
+---
+
+# Pair Programming
+
+You are a senior software engineer pair programming with a developer. Your role is to guide, explain, and teach while building together. The developer must understand every line of code in the project, so understanding is more important than speed.
+
+## Context Loading
+
+Before doing anything else, load project context:
+
+1. **Read `tandem.json`** in the project root. This is the manifest that tells you what documentation exists and where it lives. If `tandem.json` does not exist, suggest running `/create-manifest` to scan the repo and generate one. If the developer declines, work from the codebase and conversation alone.
+
+2. **Match docs to the current task.** Use the `scope`, `purpose`, and `tags` fields in each manifest entry to decide which docs are relevant. Load only what matters for this task. "Fix the pagination endpoint" loads backend and API docs, skips frontend docs. If the developer says "also check the frontend docs," load those on demand.
+
+3. **Always load docs tagged `conventions` or `architecture`** if they contain a Project Conventions section. Reference these on every sub-step to ensure generated code follows the project's standards (testing, code style, error handling, development philosophy, etc.).
+
+4. **Read the Developer Profile** from `~/.claude/CLAUDE.md` if it has a `## Developer Profile` section. Use this to calibrate:
+   - **Explanation depth:** A junior developer gets foundational context ("here's what a middleware is and why we need one"). A senior developer gets peer-level trade-off discussion ("here's why I'd pick this middleware pattern over that one").
+   - **Understanding check difficulty:** Topics in "Currently Learning" get deeper questions. Topics in "Strong Skills" get lighter questions.
+   - **Development philosophy:** Respect the developer's stated philosophy, but project-level philosophy (in the architecture doc's Project Conventions) takes precedence when both exist.
+   - If no Developer Profile exists, default to thorough explanations and adjust based on conversational cues.
+
+## Workflow
+
+### 1. Understand the Request
+
+The user will provide: $ARGUMENTS
+
+This could be a roadmap step ("step 3"), a GitHub issue number ("#12"), a feature description ("implement the search endpoint"), or a bug report.
+
+**If the user references a GitHub issue number:** Pull the issue context via `gh issue view` to get the description, user stories, acceptance criteria, and roadmap reference. Cross-reference with the doc tagged `roadmap` in the manifest if linked. If there are discrepancies between the issue and the roadmap, flag them before proceeding. If `gh` is not installed, ask the developer to provide the context manually.
+
+**If the user references a roadmap step:** Find the doc tagged `roadmap` in the manifest and read the relevant step.
+
+Confirm back what you'll be working on together.
+
+### 2. Break Into Sub-Steps
+
+Decompose the work into small, focused sub-steps. Each sub-step should be a single piece of work: one function, one endpoint, one component, one configuration change. Present the full list so the developer can see the plan, then start with sub-step 1.
+
+Example:
+
+> "To implement the data pipeline, I'd break this into these sub-steps:"
+>
+> 1. Set up the HTTP client to fetch from the API
+> 2. Write the data fetcher and parser
+> 3. Add error handling and retry logic
+> 4. Write tests
+>
+> "Let's start with sub-step 1."
+
+### 3. Explain the Sub-Step
+
+For each sub-step, explain:
+
+- **What** you're about to build and where it fits in the bigger picture
+- **Why** you're building it this way (the reasoning behind the approach)
+- **How** it works at a conceptual level before showing any code
+
+Take a mentoring tone. You are a more experienced developer walking the developer through your thought process. Don't just say what to type. Explain the reasoning so the developer could make similar decisions independently.
+
+Keep explanations focused and practical. Don't over-lecture.
+
+### 4. Ask Who Implements
+
+After explaining the sub-step, ask:
+
+> "Would you like to implement this, or should I?"
+
+- **If the developer implements:** Let them write the code. Review what they produce. If something needs adjustment, explain why and guide them to the fix rather than rewriting it.
+- **If you implement:** Write the code, then walk through what you wrote and why. Highlight the important decisions and patterns.
+
+Make sure the code is committed to the right files and the sub-step is complete before moving on.
+
+### 5. Check Understanding
+
+**First, check `tandem.json` config.** If `config.understandingChecks` is `false`, skip this step entirely and move to step 6.
+
+If understanding checks are enabled (the default), ask **three questions** to verify the developer's understanding. These should be a mix of:
+
+- **Technical questions:** "What would happen if the API returned a 503 here?" or "Why are we using this data structure instead of that one?"
+- **Conceptual questions:** "How does this function fit into the overall data pipeline?" or "Why do we compute this server-side instead of on the client?"
+- **Decision questions:** "If someone asked you why you chose this approach, what would you say?" or "What trade-offs did we make here?"
+
+**Calibrate to the developer's level** using the Developer Profile if available:
+- Topics in "Currently Learning" get harder, more foundational questions.
+- Topics in "Strong Skills" get lighter, trade-off oriented questions.
+- Topics in "Deepening" get moderate depth.
+- If no profile exists, gauge from conversational cues and adjust.
+
+After the developer answers, provide brief feedback. Correct misunderstandings, reinforce good answers, add context they might not have considered.
+
+**One-time skip:** If the developer says "skip questions" during conversation, skip for just that sub-step. Resume on the next one.
+
+### 6. Offer to Run Tests
+
+If a test framework is detected in the project (test directories, test config files, testing dependencies in package manifests), offer to run relevant tests after the sub-step:
+
+> "Want me to run the tests to make sure everything passes?"
+
+If no test framework is detected, skip this.
+
+### 7. Move to Next Sub-Step
+
+After the understanding check (or after implementation if checks are disabled), ask:
+
+> "Ready to move on to the next sub-step?"
+
+If yes, go back to step 3 with the next sub-step. If the developer has questions or wants to revisit something, address that first.
+
+### 8. Complete the Task
+
+When all sub-steps are done, summarize what was built:
+
+> "That completes [task description]. Here's what we implemented:"
+>
+> - [summary of what was built]
+> - [any decisions made along the way]
+> - [anything to keep in mind for later steps]
+
+### 9. Mark Complete (If Applicable)
+
+**If the task was a roadmap step:** Ask the developer to confirm before marking it:
+
+> "We've finished all the sub-steps for Step N. Ready for me to mark it complete?"
+
+Wait for confirmation. Then find the doc tagged `roadmap` in the manifest and update the checkbox from `- [ ]` to `- [x]`.
+
+**If the task was linked to a GitHub issue:** Offer to close it:
+
+> "This was linked to issue #N. Want me to close it?"
+
+If confirmed and `gh` is available, close via `gh issue close`.
+
+**If the task was neither:** Close out directly.
+
+After completing a roadmap step:
+
+> "When you're ready for the next step, just use `/pair-program` again."
+
+## Important Reminders
+
+- **Understanding over speed.** Every explanation should be oriented toward the developer truly understanding what was built. AI generates code; the developer owns it.
+- **No code the developer can't explain.** If you write the code, the explanation needs to be thorough enough that the developer can walk through it confidently. If the developer doesn't fully understand something, slow down and re-explain before moving on.
+- **The manifest is the source of truth for docs.** Never hardcode doc paths. Use `tandem.json` to discover and load documentation.
+- **Project conventions take precedence.** If the architecture doc has a Project Conventions section, reference it on every sub-step.
+- **Experience-agnostic.** Calibrate to whoever you're working with. A junior building their first API and a staff engineer refactoring a distributed system both get useful guidance.
+- **Never use em dashes in any written content.** Use commas, periods, colons, or semicolons instead.

--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -1,0 +1,93 @@
+---
+description: Update project documentation when plans, decisions, or requirements change. Identifies affected docs, resolves conflicts, and preserves existing structure.
+argument-hint: [what changed and why]
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Update Docs
+
+You are helping a developer update their project documentation after something changed. A requirement shifted, a tech decision was reversed, scope changed, or implementation revealed something that needs to be reflected in the docs.
+
+The trigger is always: **something changed.**
+
+## Workflow
+
+### Step 1: Understand What Changed
+
+If the developer provided context: $ARGUMENTS
+
+Ask clarifying questions if needed. Understand both *what* changed and *why* it changed. The "why" matters for determining whether this warrants an ADR.
+
+### Step 2: Identify Affected Docs
+
+Read `tandem.json` and match the change against `scope`, `purpose`, and `tags` of each doc entry. Suggest which docs are affected:
+
+> "Based on this change, I think these docs need updating:"
+> - `dev-docs/PRD.md` (scope change)
+> - `dev-docs/ARCHITECTURE.md` (component affected)
+>
+> "Does that look right, or should I check others too?"
+
+Wait for confirmation before making changes.
+
+### Step 3: Check for Conflicts
+
+Use domain-based authority to resolve conflicts across docs:
+
+| Domain | Authoritative doc |
+|---|---|
+| **What to build and why** | PRD |
+| **How to build it** | Architecture |
+| **What order to build it** | Roadmap |
+| **Why a specific technical choice was made** | ADRs |
+
+If a conflict exists (e.g., the PRD requires something the architecture can't support), flag it:
+
+> "The PRD says [X] but the architecture doc describes [Y]. The requirement stands (PRD owns what/why), so the architecture needs to evolve to meet it. Here's how I'd update the architecture: [proposal]. Sound right?"
+
+**Never silently resolve a conflict.** Always explain which domain each side falls in and confirm with the developer.
+
+### Step 4: Update Each Doc
+
+For each affected doc:
+
+1. **Read it as it actually is.** Understand its current structure, headings, and format.
+2. **Make changes within that structure.** Do not impose Tandem templates on existing docs. Do not add sections that aren't there. Do not expect a version header if there isn't one.
+3. **Preserve everything you didn't change.**
+4. **If the doc has a Tandem version header** (the two-line HTML comment at the top), update it:
+
+```markdown
+<!-- Last updated: [today's date] -->
+<!-- Last change: [brief description of what changed, with ADR reference if applicable] -->
+```
+
+5. **If a roadmap step is invalidated**, mark it clearly (strikethrough or note) rather than deleting it.
+
+### Step 5: GitHub Issue Sync
+
+If a roadmap step has a linked GitHub issue (e.g., "GitHub Issue: #12") and the step was modified:
+
+> "Step 3 changed and it's linked to issue #12. Want me to update the issue description to match?"
+
+If `gh` is available, update the issue via `gh issue edit`. If not, note which issues need manual updating.
+
+### Step 6: Architecture Enrichment
+
+For greenfield projects where the architecture doc was created in design mode (no Codebase Map or Entry Points sections), check if significant code now exists. If so, offer:
+
+> "The architecture doc doesn't have a Codebase Map or Entry Points section yet, and there's now a real codebase to document. Want me to add those sections?"
+
+If the developer agrees, scan the codebase and add these sections following the same approach as reverse-engineer mode in `/create-architecture`.
+
+### Step 7: Suggest ADR (If Significant)
+
+If the change is a significant architectural decision, suggest creating an ADR:
+
+> "This seems like a significant decision. Want me to create an ADR for it with `/create-adr`?"
+
+## Important Reminders
+
+- This is one skill, not separate "update-prd" / "update-roadmap" commands. The trigger is always "something changed."
+- Updates should be visible. Don't silently rewrite. The version header captures the latest change, and the developer can see what was modified in the diff.
+- Creation skills are opinionated (they use Tandem templates). This skill is respectful (it preserves existing structure).
+- Never use em dashes in any written content. Use commas, periods, colons, or semicolons instead.

--- a/.tandem/templates/developer-profile.md
+++ b/.tandem/templates/developer-profile.md
@@ -1,0 +1,41 @@
+## Developer Profile
+
+### About Me
+[1-3 sentences. Who you are, your experience level, what you're building toward.
+This helps Tandem skills calibrate tone: a senior engineer gets peer-level
+explanations, a junior gets more foundational context.]
+
+### Tech Stack
+[What you work with regularly. Helps creation skills suggest appropriate tools
+and make relevant design choices.]
+- **Languages:** [e.g., Python, TypeScript, C#]
+- **Frontend:** [e.g., React, React Native/Expo]
+- **Backend:** [e.g., FastAPI, Django, .NET]
+- **Data:** [e.g., PostgreSQL, Supabase, Redis]
+- **AI/ML:** [e.g., LangChain, LangGraph, OpenAI API]
+- **DevOps:** [e.g., Docker, GitHub Actions, Terraform]
+
+### Development Philosophy
+[2-4 bullet points. How you like to work. These inform how pair-program
+interacts with you.]
+- [e.g., "AI generates code, humans own it. I maintain code ownership and
+  architectural understanding."]
+- [e.g., "Avoid over-engineering. Research decisions carefully, then build
+  with minimal dependencies."]
+- [e.g., "Review before shipping. Fresh sessions to review AI-touched code."]
+
+### Currently Learning
+[Topics you're actively studying. pair-program gives the deepest explanations
+and most thorough understanding checks for these.]
+- **[Topic]**: [what specifically] (status: [not-started / in-progress])
+
+### Deepening
+[Topics you're familiar with but want production-level depth. pair-program
+gives moderate explanations.]
+- **[Topic]**: [what specifically] (status: [familiar / practicing])
+
+### Strong Skills
+[Topics where you're confident. pair-program gives light-touch explanations
+unless something unusual comes up.]
+- [Topic]
+- [Topic]

--- a/.tandem/templates/github-issue.md
+++ b/.tandem/templates/github-issue.md
@@ -1,0 +1,13 @@
+## Description
+[What this step implements, pulled from the roadmap step description]
+
+## User Stories (if applicable)
+[Pulled from the roadmap step, if user stories were included]
+- As a [user type], I want to [action] so that [outcome].
+
+## Roadmap Reference
+Step [N] in `[roadmap path from tandem.json]`
+
+## Acceptance Criteria
+- [ ] [Key deliverable or behavior that signals this step is done]
+- [ ] [Another criteria if applicable]

--- a/.tandem/templates/tandem.json
+++ b/.tandem/templates/tandem.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "config": {
+    "understandingChecks": true
+  },
+  "docs": []
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,84 @@
 # Rare: The Publishing Platform for the Discerning Writer
 
-## Getting Started
-1. Install dependencies: `npm install`
-2. Run the code `npm start`
-<!-- TODO: Update the remaining steps if anything changes -->
-3. With the server also running, check that the login, register, and logout functionality is in working.
-4. This template is using [Bulma](https://bulma.io/documentation) for styling. Take a little bit of time to familiarize yourself with the framework if you would like to continue using it.
+Rare is a full-stack publishing platform where writers create and share posts, readers discover content by tag and category, and administrators keep the platform running smoothly. This repository is the **React client** that consumes the [Rare API](https://github.com/Evening-Cohort-31/Rare-for-Python-api-fljqvv).
 
+Built by Evening Cohort 31 at [Nashville Software School](https://nashvillesoftwareschool.com) as the first full group project in the backend curriculum.
 
-<!-- TODO: Finish writing the readme -->
+---
+
+## Tech Stack
+
+![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
+![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
+![Bulma](https://img.shields.io/badge/Bulma-00D1B2?style=for-the-badge&logo=bulma&logoColor=white)
+![SQLite](https://img.shields.io/badge/SQLite-07405E?style=for-the-badge&logo=sqlite&logoColor=white)
+
+---
+
+## Related Repository
+
+| Repo | Description |
+| ---- | ----------- |
+| [Rare API](https://github.com/Evening-Cohort-31/Rare-for-Python-api-fljqvv) | Python `http.server` back end with SQLite |
+
+---
+
+## Features
+
+- **Authentication:** register, log in, and log out
+- **Posts:** create, edit, and delete posts with categories, tags, and images
+- **Comments:** add, edit, and delete comments on posts
+- **Reactions:** react to posts using emoji reactions
+- **Author Profiles:** view any author's profile and follow their content
+- **Profile Management:** update your own profile details and photo
+- **Admin Controls:** promote or demote users, manage categories and tags, deactivate authors, and delete any post
+
+---
+
+## Setup & Installation
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) v18+
+- The [Rare API](https://github.com/Evening-Cohort-31/Rare-for-Python-api-fljqvv) running locally on port `8088`
+
+### Steps
+
+1. Set up and start the [Rare API](https://github.com/Evening-Cohort-31/Rare-for-Python-api-fljqvv) first. See that repo's README for instructions.
+
+2. Clone this repository:
+
+   ```bash
+   git clone git@github.com:Evening-Cohort-31/Rare-for-Python-client-fljqvv.git
+   cd Rare-for-Python-client-fljqvv
+   ```
+
+3. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+4. Start the development server:
+
+   ```bash
+   npm start
+   ```
+
+5. Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+> The client expects the API to be available at `http://localhost:8088`. Make sure the Python server is running before starting the client.
+
+---
+
+## Contributors
+
+| Name | GitHub |
+| ---- | ------ |
+| Dale Hobbs | [@DaleHobbs-Dev](https://github.com/DaleHobbs-Dev) |
+| James Freeman | [@jamesfreeman114](https://github.com/jamesfreeman114) |
+| Nicole D'Anton | [@nicolecdanton](https://github.com/nicolecdanton) |
+| Marcus Upton | [@MDUpton1323](https://github.com/MDUpton1323) |
+| Steve Brownlee | [@stevebrownlee](https://github.com/stevebrownlee) |
+| Valerie Freeman | [@Valerie-Freeman](https://github.com/Valerie-Freeman) |

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -1,0 +1,257 @@
+<!-- Last updated: 2026-05-03 -->
+<!-- Last change: Initial architecture document (reverse-engineered from codebase) -->
+
+# Rare: The Publishing Platform - Technical Architecture
+
+## System Overview
+
+Rare is a two-repository full-stack application. This repo is the React frontend (client).
+It communicates over HTTP with a separate Python backend API that serves JSON from a
+SQLite database. Both run locally during development.
+
+```mermaid
+graph LR
+    Browser["Browser\n(React SPA)"]
+    API["Python http.server\nREST API\nlocalhost:8088"]
+    DB["SQLite Database"]
+    LS["localStorage\n(auth_token)"]
+
+    Browser -->|"HTTP fetch / JSON"| API
+    API -->|"SQL queries"| DB
+    Browser <-->|"read/write user ID"| LS
+```
+
+**Repositories:**
+- Frontend (this repo): https://github.com/Evening-Cohort-31/Rare-for-Python-client-fljqvv
+- Backend API: https://github.com/Evening-Cohort-31/Rare-for-Python-api-fljqvv
+
+## Codebase Map
+
+```
+src/
+├── index.js                      # App entry point; mounts React tree
+├── Rare.js                       # Root component; manages auth token state
+├── Rare.css / index.css          # App-level and global styles
+├── serviceWorker.js              # CRA boilerplate; not actively used
+│
+├── context/
+│   ├── CurrentUserContext.js     # React context object definition
+│   └── CurrentUserContext.jsx    # Provider component and useCurrentUser hook
+│
+├── views/
+│   ├── ApplicationViews.js       # All route definitions (React Router v6)
+│   └── Authorized.js             # Route guard: redirects unauthenticated users
+│
+├── managers/
+│   └── AuthManager.js            # Login and register fetch calls (pre-service pattern)
+│
+├── services/
+│   ├── apiSettings.js            # Base URL + shared fetch helpers (fetchJson, etc.)
+│   ├── index.js                  # Re-exports all services for clean imports
+│   ├── PostService.js            # Post CRUD
+│   ├── UserService.js            # User CRUD
+│   ├── CategoryService.js        # Category CRUD
+│   ├── CommentService.js         # Comment CRUD
+│   ├── ReactionService.js        # Reaction type lookups
+│   ├── PostReactionService.js    # User reactions on posts (upsert pattern)
+│   ├── TagService.js             # Tag CRUD
+│   ├── PostTagsService.js        # Post-tag join table operations
+│   ├── SubscriptionService.js    # Follow/subscribe to authors
+│   ├── ImageService.js           # Avatar lookups and profile image uploads
+│   └── DemotionQueue.js          # Multi-admin demotion approval workflow
+│
+├── components/
+│   ├── auth/                     # Login, Register, Authorized guard, StaffOnly guard
+│   ├── categories/               # Category list, new, edit
+│   ├── comments/                 # Comment list, edit, post-level comment view
+│   ├── nav/                      # NavBar
+│   ├── posts/                    # Post list, detail, form, new, edit, filter, approve
+│   ├── reactions/                # Reaction bar, picker dialog, create form
+│   ├── tags/                     # Tag list, new, edit
+│   ├── users/                    # User profiles, user detail, subscribe button, modals
+│   └── utils/                    # HumanDate formatter, imageUtils helpers
+│
+├── design/
+│   ├── index.js                  # Re-exports all design system components
+│   ├── design.css                # Design system styles
+│   ├── Button.js, Card.js, ...   # Reusable UI primitives wrapping Bulma classes
+│   └── bulma-reference/          # Bulma demo components (dev reference; not used in production)
+│
+└── bulma/                        # Older duplicate of bulma-reference; superseded by design/
+```
+
+## Entry Points
+
+1. `src/index.js` creates the React root and wraps the entire tree in three providers:
+   `<BrowserRouter>`, `<CurrentUserProvider>`, and `<Rare>`.
+2. `src/Rare.js` reads `auth_token` from `localStorage` on mount, holds it in state,
+   and renders `<NavBar>` and `<ApplicationViews>` with the token passed as a prop.
+3. `<CurrentUserProvider>` runs a `useEffect` on mount: if an `auth_token` exists in
+   `localStorage`, it fetches the full user object from `GET /users/:id` and stores it
+   in context. This is what populates `currentUser` throughout the app.
+4. `src/views/ApplicationViews.js` registers all routes. Unauthenticated routes (login,
+   register, access-denied) are public. Everything else is wrapped in `<Authorized>`,
+   and staff-only pages are additionally wrapped in `<StaffOnly>`.
+
+## Component Breakdown
+
+### Auth Guards
+- **`Authorized`**: Reads `currentUser` from context. Redirects to `/login` if no user
+  is present; otherwise renders child routes via `<Outlet>`.
+- **`StaffOnly`**: Same as `Authorized` but additionally checks `currentUser.is_staff`.
+  Redirects to `/access-denied` if the user is not staff.
+
+### Current User Context
+Provides `currentUser`, `setCurrentUser`, `isLoading`, and `fetchUserData` to the
+entire component tree. Components call `useCurrentUser()` to access the logged-in user
+without prop drilling.
+
+### Services Layer
+All API communication goes through `src/services/`. The pattern:
+1. `apiSettings.js` defines the base URL and four shared helpers:
+   `fetchJson` (GET), `postJson` (POST), `putJson` (PUT), `deleteJson` (DELETE).
+2. Domain service files (e.g., `PostService.js`) call these helpers with specific
+   endpoints and return the resulting promises.
+3. `services/index.js` re-exports everything so components import from one place:
+   `import { getAllPosts, createPost } from "../services"`.
+
+**Note:** `AuthManager.js` predates this pattern and calls `fetch` directly instead of
+using the shared helpers. It is not re-exported from `services/index.js`.
+
+### Design System
+`src/design/` is a set of thin wrapper components (Button, Card, FormField, etc.) that
+apply Bulma CSS classes. This keeps Bulma class names out of feature components and
+provides a single place to update styling tokens. The `bulma-reference/` subdirectory
+holds demo/reference components used during development; it is not part of the production UI.
+
+### Admin: Demotion Queue
+The demotion queue is a custom workflow to prevent accidentally removing the last admin.
+When one admin initiates a demotion of another, an entry is created in `/demotionqueue`
+with `status: pending`. A second admin must confirm before the demotion takes effect.
+This logic lives in `DemotionQueue.js` and the `ChangeUserTypeModal` component.
+
+## Data Model
+
+The schema below is inferred from the frontend service layer. The authoritative schema
+lives in the backend repo. Field names and exact types may differ slightly.
+
+```dbml
+Table users {
+  id integer [pk]
+  username varchar [not null, unique]
+  password varchar [not null]
+  is_staff boolean [default: false]
+  active boolean [default: true]
+  bio text
+  profile_image_url varchar
+  created_on date
+}
+
+Table posts {
+  id integer [pk]
+  user_id integer [ref: > users.id]
+  category_id integer [ref: > categories.id]
+  title varchar [not null]
+  content text [not null]
+  image_url varchar
+  publication_date date
+  approved boolean [default: false]
+}
+
+Table categories {
+  id integer [pk]
+  label varchar [not null, unique]
+}
+
+Table tags {
+  id integer [pk]
+  label varchar [not null, unique]
+}
+
+Table post_tags {
+  id integer [pk]
+  post_id integer [ref: > posts.id]
+  tag_id integer [ref: > tags.id]
+}
+
+Table comments {
+  id integer [pk]
+  post_id integer [ref: > posts.id]
+  user_id integer [ref: > users.id]
+  content text [not null]
+  created_on date
+}
+
+Table reactions {
+  id integer [pk]
+  label varchar [not null]
+  image_url varchar
+}
+
+Table post_reactions {
+  id integer [pk]
+  post_id integer [ref: > posts.id]
+  user_id integer [ref: > users.id]
+  reaction_id integer [ref: > reactions.id]
+}
+
+Table subscriptions {
+  id integer [pk]
+  follower_id integer [ref: > users.id]
+  author_id integer [ref: > users.id]
+  created_on date
+}
+
+Table demotion_queue {
+  id integer [pk]
+  initiator_id integer [ref: > users.id]
+  target_admin_id integer [ref: > users.id]
+  status varchar [not null]
+}
+```
+
+## API Design
+
+**Base URL:** `http://localhost:8088`
+
+The backend implements a REST-like API using Python's `http.server`. It supports
+filtering via query parameters (e.g., `?user_id=1`) and related-resource expansion
+(e.g., `?_expand=category`), a pattern similar to JSON Server.
+
+| Domain           | Endpoints                                                         |
+|------------------|-------------------------------------------------------------------|
+| Auth             | `POST /login`, `POST /register`                                   |
+| Users            | `GET /users`, `GET /users/:id`, `PUT /users/:id`                  |
+| Posts            | `GET /posts`, `GET /posts/:id`, `POST /posts`, `PUT /posts/:id`, `DELETE /posts/:id` |
+| Categories       | `GET /categories`, `POST /categories`, `PUT /categories/:id`, `DELETE /categories/:id` |
+| Tags             | `GET /tags`, `POST /tags`, `PUT /tags/:id`, `DELETE /tags/:id`    |
+| Post Tags        | `GET /posttags?post_id=:id`, `POST /posttags`, `DELETE /posttags/:id` |
+| Comments         | `GET /comments?post_id=:id`, `POST /comments`, `PUT /comments/:id`, `DELETE /comments/:id` |
+| Reactions        | `GET /reactions`, `POST /reactions`                               |
+| Post Reactions   | `GET /postreactions`, `GET /postreactions?post_id=:id`, `PUT /postreactions` (upsert) |
+| Subscriptions    | `GET /subscriptions`, `POST /subscriptions`, `DELETE /subscriptions/:id` |
+| Images           | `GET /avatars`, `GET /profile-images?user_id=:id`, `POST /profile-images` (multipart) |
+| Demotion Queue   | `GET /demotionqueue`, `POST /demotionqueue`, `PUT /demotionqueue/:id`, `DELETE /demotionqueue/:id` |
+
+**Auth approach:** The backend returns a user ID on login. The frontend stores it in
+`localStorage` as `auth_token` (format: `{"id": <userId>}`). Subsequent requests do not
+pass an auth header; the user ID is supplied via query parameter or request body as
+needed. This is a simplified trust model appropriate for a local learning project.
+
+## Infrastructure and Deployment
+
+This project runs entirely on localhost. There is no CI/CD pipeline, no staging
+environment, and no production deployment. Both the React dev server (`npm start`,
+port 3000) and the Python API server (port 8088) must be running simultaneously for
+the app to function.
+
+## Unanswered Questions
+
+- **Post approval workflow:** `ApprovePostButton.jsx` exists but the approval flow
+  (who triggers it, what state it changes, whether unapproved posts are hidden from
+  non-staff) is not fully clear from the frontend alone. Check the backend repo for the
+  `approved` field handling.
+- **Exact user schema:** Fields like `bio` and `profile_image_url` on the `users` table
+  are inferred from the UI. Verify against the backend's database seed or migration files.
+- **Image storage:** Profile images are uploaded to `POST /profile-images` on the Python
+  server. It is unclear whether the backend stores them on disk or in the SQLite database.

--- a/dev-docs/PRD.md
+++ b/dev-docs/PRD.md
@@ -1,0 +1,95 @@
+<!-- Last updated: 2026-05-03 -->
+<!-- Last change: Initial PRD creation -->
+
+# Rare: The Publishing Platform for the Discerning Writer - Product Requirements Document
+
+## Problem Statement
+Rare was built as the first group project in the backend curriculum at Nashville Software
+School (Evening Cohort 31). The goal was to apply Python fundamentals by building a
+functioning full-stack publishing platform. Students implemented a REST-like API using
+Python's built-in `http.server` module with hand-written CRUD operations, paired with a
+React frontend. The project ran across five sprints using a kanban-style board with story
+points, sprint planning, and sprint retrospectives.
+
+## Target Users
+- **Writers/Authors:** Users who create and publish posts on topics of their choosing,
+  using tags, categories, and images.
+- **Readers:** Users who browse posts, react to content, comment on posts, and follow
+  authors whose work they enjoy.
+- **Administrators:** Users with elevated privileges who manage the platform by
+  moderating users, content, and taxonomy.
+
+## Core Requirements
+
+### Authentication
+- Users can register, log in, and log out.
+
+### Posts
+- Authenticated users can create, edit, and delete their own posts.
+- Posts support tags, categories, and images.
+- Admins can delete any post.
+
+### Comments
+- Users can comment on posts.
+- Users can edit and delete their own comments.
+
+### Reactions
+- Users can react to posts made by other users.
+
+### Author Profiles
+- Users can view any author's public profile.
+- Users can follow or subscribe to an author.
+
+### Profile Management
+- Users can edit select details on their own profile.
+
+### Admin Controls
+- Admins can promote or demote users.
+- Admins can add new categories and tags.
+- Admins can mark authors as inactive.
+
+## Technical Stack
+
+### Stack Decisions
+- **Frontend:** React with Bulma CSS. React was the cohort's primary frontend framework;
+  Bulma provided utility-first styling without requiring a heavy build setup.
+- **Backend:** Python with `http.server`. No framework was used; the cohort hand-wrote
+  all routing and CRUD logic to build foundational understanding of how HTTP and data
+  persistence work before introducing a framework like Django.
+- **Database:** SQLite. A lightweight file-based database suited to a local development
+  project at this scale.
+- **Version Control:** Git and GitHub with a PR-based branch review workflow.
+
+## Scope
+
+### In Scope (Completed across Sprints 1-5)
+- User registration, login, and logout
+- Post creation, editing, and deletion (author or admin)
+- Post tagging, categorization, and image association
+- Reactions to posts
+- Comments on posts (create, edit, delete)
+- Author profile viewing and follow/subscribe
+- User profile self-editing
+- Admin: promote/demote users, add categories/tags, deactivate authors, delete any post
+
+### Out of Scope
+- Notifications
+- Search or advanced filtering beyond tag/category
+- Mobile-specific design
+- Deployment to a production environment
+
+## Success Criteria
+- All five sprint deliverables completed and merged.
+- Core user flows (register, post, comment, react, follow, admin actions) function
+  without errors.
+- Frontend and backend integrate correctly via the hand-written Python API.
+
+## Learning Goals
+- Build foundational understanding of HTTP request/response cycles by implementing
+  routing and CRUD without a framework.
+- Practice React component architecture and state management across a multi-feature app.
+- Develop team collaboration habits: branching, PR reviews, and sprint-based delivery.
+- Understand full-stack integration by connecting a React frontend to a custom Python
+  backend.
+- Experience an agile workflow end-to-end: kanban board, sprint planning, story point
+  estimation, self-selected tickets, and sprint retrospectives.

--- a/tandem.json
+++ b/tandem.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "config": {
+    "understandingChecks": true
+  },
+  "docs": [
+    {
+      "path": "README.md",
+      "scope": "general",
+      "purpose": "Project overview and getting started guide for the Rare publishing platform, including setup steps and notes on the Bulma CSS framework",
+      "tags": ["getting-started"]
+    },
+    {
+      "path": "pull_request_template.md",
+      "scope": "general",
+      "purpose": "Pull request template defining the required sections (description, changes, testing steps, notes) and workflow tips for contributors",
+      "tags": ["contributing", "workflow"]
+    },
+    {
+      "path": "dev-docs/PRD.md",
+      "scope": "general",
+      "purpose": "Product requirements, target users, tech stack decisions, project scope, and learning goals for the Rare publishing platform",
+      "tags": ["prd", "requirements", "scope", "stack"]
+    },
+    {
+      "path": "dev-docs/ARCHITECTURE.md",
+      "scope": "general",
+      "purpose": "System design, codebase map, entry points, component breakdown, inferred data model, API endpoint reference, and infrastructure notes",
+      "tags": ["architecture", "system-design", "data-model", "api"]
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Added project documentation that was missing from the repo. This includes a complete rewrite of the README, a Product Requirements Document, a Technical Architecture Document, and a Tandem manifest file that ties them all together. The README was modeled after a reference example and covers the project description, tech stack badges, features, setup instructions for both repos, and contributors. The PRD and architecture doc live in a new `dev-docs/` directory and serve as reference material for the project.

## Changes
- [ ] Bug fix
- [x] New feature
Note: This is a documentation-only change. "New feature" is the closest fit since all files are net-new additions.

## Testing
- Confirmed all four files render correctly as markdown
- Verified all external links in README.md point to valid GitHub profiles and repos
- Confirmed `tandem.json` correctly references all three doc paths

## Notes
- `tandem.json` is used by the Tandem command system in Claude Code. It acts as a table of contents for project docs and enables context-aware pair programming sessions.
- The data model in `ARCHITECTURE.md` is inferred from the frontend service layer, not the actual SQLite schema. It should be verified against the backend repo if the schema ever needs to be authoritative.
- `dev-docs/` is a new directory. No existing files were modified except `README.md`.